### PR TITLE
Fixed `basename` error on `bpkg --help`

### DIFF
--- a/bpkg.sh
+++ b/bpkg.sh
@@ -27,7 +27,7 @@ commands () {
     declare -a local cmds=( $(
       bpkg-suggest 'bpkg-' |
       tail -n+2            |
-      xargs basename       |
+      xargs basename -a    |
       sort -u              |
       sed 's/bpkg-//g'     |
       tr '\n' ' '


### PR DESCRIPTION
Added basename option to support multiple arguments
