### PR TITLE
package: add repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,5 +3,6 @@
   "version": "0.2.6",
   "description": "Lightweight bash package manager",
   "global": true,
+  "repo": "bpkg/bpkg",
   "install": "make install"
 }


### PR DESCRIPTION
Add `repo` to `package.json` for warning do not appear when installing with `clib`.
It looks this way:

``` sh
$ clib install bpkg/bpkg
      fetch : https://raw.githubusercontent.com/bpkg/bpkg/master/package.json
    warning : missing repo in package.json
  info: Uninstalling /usr/local/bin/bpkg...
  info: Installing /usr/local/bin/bpkg...
```
