### PR TITLE
readme: about script to deps/bin in local install

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ $ bpkg install term
 $ ./deps/term/term.sh
 ```
 
+After a local install the `term.sh` script is copied as `term` to the `deps/bin` directory, you can add this directory to the `PATH` with
+
+```sh
+export PATH=$PATH:/path_to_bkpg/deps/bin
+```
+
 As a bonus, you can specify a **specific version**:
 
 ```sh


### PR DESCRIPTION
In readme.md a short description description about the change in commit 248b2d1cfbec204fd0ed1039af816656ce226afe .

After a local install the scripts are copied to `deps/bin` directory and how add this directory to `PATH` .