### PR TITLE
Make curl-based install command easier to copy and paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Our install script is the simplest way. It takes care of everything for you, pla
 Paste the following on your shell and you're good to go:
 
 ```sh
-$ curl -Lo- http://get.bpkg.io| bash
+$ curl -Lo- http://get.bpkg.io | bash
 ```
 
 ### 2. clib


### PR DESCRIPTION
It might look like a meaningless whitespace that was introduced, but it does make a difference because when I copied and pasted the previous command into my zsh terminal, it was automatically adjusted to
```
❯ curl -Lo- http://get.bpkg.io\| bash
```
(notice the backslash before the pipe)

That doesn't happen if there's a space before the pipe.