### PR TITLE
Add recursive dependency resolution via package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ $ bpkg install stephenmathieson/git-standup -g
 cp -f git-standup /usr/local/bin
 ```
 
+### Packages With Dependencies
+
+You can install a packages dependencies with the `bpkg getdeps` command. These will recursively install in `deps/` sub-folders to resolve all dependencies.
+
+_Note: There is no protection against circular dependencies, so be careful!_
+
+
 ### Retrieving package info
 
 After installing a package, you can obtain info from it using `bpkg`.
@@ -194,6 +201,17 @@ This is an array of scripts that will be installed into a project.
 ```json
   "scripts": ["script.sh"]
 ```
+
+### dependencies (optional)
+ 
+This is a hash of dependencies. The keys are the package names, and the values are the version specifiers. If you want the latest code use `'master'` in the version specifier. Otherwise, use a tagged release identifier. This works the same as `bpkg install`'s package/version specifiers. 
+
+```json
+  "dependencies": {
+    "term": "0.0.1"
+  }
+```
+
 
 ## Packaging best practices
 

--- a/bpkg-getdeps
+++ b/bpkg-getdeps
@@ -1,0 +1,1 @@
+lib/getdeps/getdeps.sh

--- a/lib/getdeps/getdeps.sh
+++ b/lib/getdeps/getdeps.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+## output usage
+usage () {
+  echo "Installs dependencies for a package."
+  echo "usage: bpkg-getdeps [-h|--help]"
+  echo "   or: bpkg-getdeps"
+}
+
+## Read a package property
+bpkg_getdeps () {
+  local cwd="`pwd`"
+  local pkg="${cwd}/package.json"
+
+  ## parse flags
+  case "$1" in
+    -h|--help)
+      usage
+      return 0
+      ;;
+  esac
+
+  ## ensure there is a package to read
+  if ! test -f "${pkg}"; then
+    echo 2>&1 "error: Unable to find \`package.json' in `pwd`"
+    return 1
+  fi
+
+  dependencies=$(cat "${pkg}" | bpkg-json -b | grep '\[\"dependencies' | sed "s/\[\"dependencies\",//" | sed "s/\"\]$(printf '\t')\"/@/" | tr -d '"')
+  dependencies=($(echo ${dependencies[@]}))
+
+  ## run bpkg install for each dependency
+  for (( i = 0; i < ${#dependencies[@]} ; ++i )); do
+    (
+      local package=${dependencies[$i]}
+      bpkg install ${package}
+    )
+  done
+  return 0
+}
+
+if [[ ${BASH_SOURCE[0]} != $0 ]]; then
+  export -f bpkg_getdeps
+else
+  bpkg_getdeps "${@}"
+  exit $?
+fi

--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -358,6 +358,8 @@ bpkg_install_from_remote () {
         chmod u+x "${cwd}/deps/bin/${scriptname}"
       )
     done
+    # install package dependencies
+    (cd ${cwd}/deps/${name} && bpkg getdeps)
   fi
 
   return 0


### PR DESCRIPTION
This PR partially resolves issue #43 .

Some notes: 
- Adds command `bpkg getdeps` which install dependencies based on `package.json` 
- Uses the same package naming/version info as `bpkg install`
- Requiring relative-pathed libraries is kind of hard, since you don't always know where the Bash script is located, so can't always find the dependency path. 

See an example implementation in these two repos:
- https://github.com/thoward/howdy (depends on `bpkg/term`)
- https://github.com/thoward/usehowdy (depends on `thoward/howdy`)

You'll see that it can follow a chain of dependencies to install the entire graph. 

_NOTE: It does NOT check for circular dependencies, so could go in an infinite loop if folks aren't careful about that._

The `require` function used in the examples can be seen here: https://github.com/thoward/howdy/blob/master/howdy.sh#L3

It has some flaws, in that it doesn't follow links. Also, how to avoid copying it into every script? It's a chicken-and-the-egg problem. How to require the require function? :) 

This may not be a complete implementation, but it's a mostly functional starting point.