### PR TITLE
updated setup.sh to install getdeps

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -63,7 +63,7 @@ BIN="bpkg"
 [ -z "$PREFIX" ] && PREFIX="/usr/local"
 
 # All 'bpkg' supported commands
-CMDS="json install package term suggest init utils update list show"
+CMDS="json install package term suggest init utils update list show getdeps"
 
 make_install () {
   make_uninstall


### PR DESCRIPTION
this prevents the error 'error: `getdeps' is not a bpkg command.'