### PR TITLE
Fix template return code generated by `bpkg init`

### DIFF
--- a/lib/init/init.sh
+++ b/lib/init/init.sh
@@ -234,7 +234,7 @@ create_shell_file () {
       echo "  export -f $NAME"
       echo 'else'
       echo "  $NAME "'"${@}"'
-      echo "  exit $?"
+      echo '  exit $?'
       echo 'fi'
     } > "${NAME}.sh"
     chmod 755 "${NAME}.sh"


### PR DESCRIPTION
I noticed that `bpkg init` would generate a template script that, when executed, would always exit with status zero, regardless of the intended return value. Now, the template uses `exit $?`, which respects the return value of the main function.

Judging by the code, it looks like this was just a mistake of using double quotes instead of single quotes (I can't imagine why double quotes would've been the intended behavior).