### PR TITLE
Clarify that "username" means "Github username"

### DIFF
--- a/lib/init/init.sh
+++ b/lib/init/init.sh
@@ -109,7 +109,7 @@ prompts () {
   prompt DESCRIPTION "description: "
   prompt INSTALL "install: (${INSTALL})"
   prompt SCRIPTS "scripts: (${SCRIPTS}) "
-  prompt USER "username: (${USER}) "
+  prompt USER "Github username: (${USER}) "
   prompt_if "Force global install?" set_global
 }
 


### PR DESCRIPTION
When using `bpkg init`, I was initially confused by what the "username" prompt meant. After reading the generated README for my package, I assume it must mean "Github username." In this pull request, I clarify that.

If `bpkg` currently supports (or intends to soon support) a way of distributing packages outside of Github (and therefore "username" has more than one meaning), feel free to disregard this. Otherwise, I think it might alleviate some user confusion.

Cheers!