### PR TITLE
Preventing Double Install

### DIFF
--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -283,18 +283,6 @@ bpkg_install_from_remote () {
       tr -d ' '
     )"
 
-    ## copy package.json over
-    curl $auth_param -sL "${url}/package.json" -o "${cwd}/deps/${name}/package.json"
-
-    ## make `deps/' directory if possible
-    mkdir -p "${cwd}/deps/${name}"
-
-    ## make `deps/bin' directory if possible
-    mkdir -p "${cwd}/deps/bin"
-
-    # install package dependencies
-    (cd "${cwd}/deps/${name}" && bpkg getdeps)
-
     ## check if forced global
     if [ ! -z $(echo -n $json | bpkg-json -b | grep '\["global"\]' | awk '{ print $2 }' | tr -d '"') ]; then
       needs_global=1
@@ -365,6 +353,18 @@ bpkg_install_from_remote () {
     )}
   ## perform local install otherwise
   else
+    ## copy package.json over
+    curl $auth_param -sL "${url}/package.json" -o "${cwd}/deps/${name}/package.json"
+
+    ## make `deps/' directory if possible
+    mkdir -p "${cwd}/deps/${name}"
+
+    ## make `deps/bin' directory if possible
+    mkdir -p "${cwd}/deps/bin"
+
+    # install package dependencies
+    (cd "${cwd}/deps/${name}" && bpkg getdeps)
+
     if [ "${#scripts[@]}" -gt "0" ]; then
       ## grab each script and place in deps directory
       for (( i = 0; i < ${#scripts[@]} ; ++i )); do

--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -363,36 +363,38 @@ bpkg_install_from_remote () {
         ## clean up
       rm -rf ${name}-${version}
     )}
-  fi
-  if [ "${#scripts[@]}" -gt "0" ]; then
-    ## grab each script and place in deps directory
-    for (( i = 0; i < ${#scripts[@]} ; ++i )); do
-      (
-        local script="$(echo ${scripts[$i]} | xargs basename )"
-        info "fetch" "${url}/${script}"
-        info "write" "${cwd}/deps/${name}/${script}"
-        curl $auth_param -sL "${url}/${script}" -o "${cwd}/deps/${name}/${script}"
-        local scriptname="${script%.*}"
-        info "${scriptname} to PATH" "${cwd}/deps/bin/${scriptname}"
-        ln -si "${cwd}/deps/${name}/${script}" "${cwd}/deps/bin/${scriptname}"
-        chmod u+x "${cwd}/deps/bin/${scriptname}"
-      )
-    done
-  fi
-  if [ "${#files[@]}" -gt "0" ]; then
-    ## grab each file
-    for (( i = 0; i < ${#files[@]} ; ++i )); do
-      (
-        local file="$(echo ${files[$i]})"
-        local filedir="$(dirname "${cwd}/deps/${name}/${file}")"
-        info "fetch" "${url}/${file}"
-        if [ ! -d "$filedir" ]; then
-          mkdir -p "$filedir"
-        fi
-        info "write" "${filedir}/${file}"
-        curl $auth_param -sL "${url}/${script}" -o "${filedir}/${file}"
-      )
-    done
+  ## perform local install otherwise
+  else
+    if [ "${#scripts[@]}" -gt "0" ]; then
+      ## grab each script and place in deps directory
+      for (( i = 0; i < ${#scripts[@]} ; ++i )); do
+        (
+          local script="$(echo ${scripts[$i]} | xargs basename )"
+          info "fetch" "${url}/${script}"
+          info "write" "${cwd}/deps/${name}/${script}"
+          curl $auth_param -sL "${url}/${script}" -o "${cwd}/deps/${name}/${script}"
+          local scriptname="${script%.*}"
+          info "${scriptname} to PATH" "${cwd}/deps/bin/${scriptname}"
+          ln -si "${cwd}/deps/${name}/${script}" "${cwd}/deps/bin/${scriptname}"
+          chmod u+x "${cwd}/deps/bin/${scriptname}"
+        )
+      done
+    fi
+    if [ "${#files[@]}" -gt "0" ]; then
+      ## grab each file
+      for (( i = 0; i < ${#files[@]} ; ++i )); do
+        (
+          local file="$(echo ${files[$i]})"
+          local filedir="$(dirname "${cwd}/deps/${name}/${file}")"
+          info "fetch" "${url}/${file}"
+          if [ ! -d "$filedir" ]; then
+            mkdir -p "$filedir"
+          fi
+          info "write" "${filedir}/${file}"
+          curl $auth_param -sL "${url}/${script}" -o "${filedir}/${file}"
+        )
+      done
+    fi
   fi
   return 0
 }


### PR DESCRIPTION
The existing behaviour was to perform a global install in addition to a local one rather than instead of. I have just moved the local code into the else branch of the existing if for the global install.

Now this fixes #70 , however honestly global installs do not work at all as is and should be either disabled or completely reworked. All they do right now is grab a git repo and call `make install` rather than performing a local install somewhere like `/opt/bpkg` and adding an additional link for the bin into `/usr/local/bin` (which would probably actually be easier than what it is trying to do now). The current behaviour likely to be dangerous and unexpected for users and developers.

As is to prevent it from making some useless root owned folders in the current directory I also moved all the code that touches cwd into the local branch, that includes trying to install dependencies(which it would have just done locally anyway).