### PR TITLE
Issues 78 - Makes `install.sh` more shellcheck compliant.

### DIFF
--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -114,6 +114,15 @@ url_exists () {
     return "${exists}"
 }
 
+read_package_json () {
+  local auth_param url
+
+  url="${1}"
+  auth_param="${2}"
+
+  gurl "${url}" "${auth_param}" '-L'
+}
+
 # [G]et from [URL]
 #
 # Very thin wrapper that passes all non-empty parameters to "curl"
@@ -316,7 +325,7 @@ bpkg_install_from_remote () {
   }
 
   ## read package.json
-  json=$(gurl "${url}/package.json?$(date +%s)" "${auth_param}" '-L')
+  json=$(read_package_json "${url}/package.json?$(date +%s)" "${auth_param}")
 
   if (( 1 == has_pkg_json )); then
     ## get package name from 'package.json'

--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -2,18 +2,18 @@
 
 # Include config rc file if found
 CONFIG_FILE="$HOME/.bpkgrc"
-[ -f "$CONFIG_FILE" ] && source "$CONFIG_FILE"
+[[ -f "$CONFIG_FILE" ]] && source "$CONFIG_FILE"
 
 ## set defaults
-if [ ${#BPKG_REMOTES[@]} -eq 0 ]; then
+if [[ ${#BPKG_REMOTES[@]} -eq 0 ]]; then
   BPKG_REMOTES[0]=${BPKG_REMOTE-https://raw.githubusercontent.com}
   BPKG_GIT_REMOTES[0]=${BPKG_GIT_REMOTE-https://github.com}
 fi
-BPKG_USER="${BPKG_USER:-"bpkg"}"
+BPKG_USER="${BPKG_USER:-bpkg}"
 
 ## check parameter consistency
 validate_parameters () {
-  if [ ${#BPKG_GIT_REMOTES[@]} -ne ${#BPKG_REMOTES[@]} ]; then
+  if [[ ${#BPKG_GIT_REMOTES[@]} -ne ${#BPKG_REMOTES[@]} ]]; then
     mesg='BPKG_GIT_REMOTES[%d] differs in size from BPKG_REMOTES[%d] array'
     fmesg=$(printf "$mesg" "${#BPKG_GIT_REMOTES[@]}" "${#BPKG_REMOTES[@]}")
     error "$fmesg"
@@ -127,7 +127,7 @@ bpkg_install () {
   local let needs_global=0
 
   for opt in "${@}"; do
-    if [ '-' = "${opt:0:1}" ]; then
+    if [[ '-' = "${opt:0:1}" ]]; then
       continue
     fi
     pkg="${opt}"
@@ -147,7 +147,7 @@ bpkg_install () {
         ;;
 
       *)
-        if [ '-' = "${opt:0:1}" ]; then
+        if [[ '-' = "${opt:0:1}" ]]; then
           echo 2>&1 "error: Unknown argument \`${1}'"
           usage
           return 1
@@ -157,7 +157,7 @@ bpkg_install () {
   done
 
   ## ensure there is a package to install
-  if [ -z "${pkg}" ]; then
+  if [[ -z "${pkg}" ]]; then
     usage
     return 1
   fi
@@ -169,9 +169,9 @@ bpkg_install () {
   for remote in "${BPKG_REMOTES[@]}"; do
     local git_remote=${BPKG_GIT_REMOTES[$i]}
     bpkg_install_from_remote "$pkg" "$remote" "$git_remote" $needs_global
-    if [ "$?" == '0' ]; then
+    if [[ "$?" == '0' ]]; then
       return 0
-    elif [ "$?" == '2' ]; then
+    elif [[ "$?" == '2' ]]; then
       error 'fatal error occurred during install'
       return 1
     fi
@@ -216,10 +216,10 @@ bpkg_install_from_remote () {
     IFS="${OLDIFS}"
   }
 
-  if [ ${#pkg_parts[@]} -eq 1 ]; then
+  if [[ ${#pkg_parts[@]} -eq 1 ]]; then
     version='master'
     #info "Using latest (master)"
-  elif [ ${#pkg_parts[@]} -eq 2 ]; then
+  elif [[ ${#pkg_parts[@]} -eq 2 ]]; then
     name="${pkg_parts[0]}"
     version="${pkg_parts[1]}"
   else
@@ -235,10 +235,10 @@ bpkg_install_from_remote () {
     IFS="${OLDIFS}"
   }
 
-  if [ ${#pkg_parts[@]} -eq 1 ]; then
+  if [[ ${#pkg_parts[@]} -eq 1 ]]; then
     user="${BPKG_USER}"
     name="${pkg_parts[0]}"
-  elif [ ${#pkg_parts[@]} -eq 2 ]; then
+  elif [[ ${#pkg_parts[@]} -eq 2 ]]; then
     user="${pkg_parts[0]}"
     name="${pkg_parts[1]}"
   else
@@ -253,7 +253,7 @@ bpkg_install_from_remote () {
 
 
   ## check to see if remote is raw with oauth (GHE)
-  if [ "${remote:0:10}" == "raw-oauth|" ]; then
+  if [[ "${remote:0:10}" == "raw-oauth|" ]]; then
     info 'Using OAUTH basic with content requests'
     OLDIFS="${IFS}"
     IFS="'|'"
@@ -319,7 +319,7 @@ bpkg_install_from_remote () {
     )"
 
     ## check if forced global
-    if [ ! -"z $(echo -n "${json}" | bpkg-json -b | grep '\["global"\]' | awk '{ print $2 }' | tr -d '"')" ]; then
+    if [[ ! -"z $(echo -n "${json}" | bpkg-json -b | grep '\["global"\]' | awk '{ print $2 }' | tr -d '"')" ]]; then
       needs_global=1
     fi
 
@@ -361,7 +361,7 @@ bpkg_install_from_remote () {
       build="$(echo -n "${build}" | sed -e 's/^ *//' -e 's/ *$//')"
     fi
 
-    if [ -z "${build}" ]; then
+    if [[ -z "${build}" ]]; then
       warn 'Missing build script'
       warn 'Trying `make install`...'
       build='make install'
@@ -369,7 +369,7 @@ bpkg_install_from_remote () {
 
     { (
       ## go to tmp dir
-      cd "$( [ ! -z "${TMPDIR}" ] && echo "${TMPDIR}" || echo /tmp)" &&
+      cd "$( [[ ! -z "${TMPDIR}" ]] && echo "${TMPDIR}" || echo /tmp)" &&
         ## prune existing
       rm -rf "${name}-${version}" &&
         ## shallow clone
@@ -400,7 +400,7 @@ bpkg_install_from_remote () {
     # install package dependencies
     (cd "${cwd}/deps/${name}" && bpkg getdeps)
 
-    if [ "${#scripts[@]}" -gt '0' ]; then
+    if [[ "${#scripts[@]}" -gt '0' ]]; then
       ## grab each script and place in deps directory
       for (( i = 0; i < ${#scripts[@]} ; ++i )); do
         (
@@ -415,14 +415,14 @@ bpkg_install_from_remote () {
         )
       done
     fi
-    if [ "${#files[@]}" -gt '0' ]; then
+    if [[ "${#files[@]}" -gt '0' ]]; then
       ## grab each file
       for (( i = 0; i < ${#files[@]} ; ++i )); do
         (
           local file="${files[$i]}"
           local filedir="$(dirname "${cwd}/deps/${name}/${file}")"
           info "fetch" "${url}/${file}"
-          if [ ! -d "${filedir}" ]; then
+          if [[ ! -d "${filedir}" ]]; then
             mkdir -p "${filedir}"
           fi
           info "write" "${filedir}/${file}"

--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -24,9 +24,9 @@ validate_parameters () {
 
 ## outut usage
 usage () {
-  echo "usage: bpkg-install [-h|--help]"
-  echo "   or: bpkg-install [-g|--global] <package>"
-  echo "   or: bpkg-install [-g|--global] <user>/<package>"
+  echo 'usage: bpkg-install [-h|--help]'
+  echo '   or: bpkg-install [-g|--global] <package>'
+  echo '   or: bpkg-install [-g|--global] <user>/<package>'
 }
 
 ## format and output message
@@ -43,7 +43,7 @@ message () {
     bpkg-term reset
   fi
 
-  printf ": "
+  printf ': '
 
   if type -f bpkg-term > /dev/null 2>&1; then
     bpkg-term reset
@@ -60,25 +60,25 @@ message () {
 ## output error
 error () {
   {
-    message "red" "error" "${@}"
+    message 'red' 'error' "${@}"
   } >&2
 }
 
 ## output warning
 warn () {
   {
-    message "yellow" "warn" "${@}"
+    message 'yellow' 'warn' "${@}"
   } >&2
 }
 
 ## output info
 info () {
-  local title="info"
+  local title='info'
   if (( "${#}" > 1 )); then
     title="${1}"
     shift
   fi
-  message "cyan" "${title}" "${@}"
+  message 'cyan' "${title}" "${@}"
 }
 
 
@@ -96,7 +96,7 @@ url_exists () {
     # In some rare cases, curl will return CURLE_WRITE_ERROR (23) when writing
     # to `/dev/null`. In such a case we do not care that such an error occured.
     # We are only interested in the status, which *will* be available regardless.
-    if [[ "0" != "${result}" && '23' != "${result}" ]] || (( status >= 400 )); then
+    if [[ '0' != "${result}" && '23' != "${result}" ]] || (( status >= 400 )); then
       exists=1
     fi
 
@@ -123,11 +123,11 @@ gurl () {
 
 ## Install a bash package
 bpkg_install () {
-  local pkg=""
+  local pkg=''
   local let needs_global=0
 
   for opt in "${@}"; do
-    if [ "-" = "${opt:0:1}" ]; then
+    if [ '-' = "${opt:0:1}" ]; then
       continue
     fi
     pkg="${opt}"
@@ -147,7 +147,7 @@ bpkg_install () {
         ;;
 
       *)
-        if [ "-" = "${opt:0:1}" ]; then
+        if [ '-' = "${opt:0:1}" ]; then
           echo 2>&1 "error: Unknown argument \`${1}'"
           usage
           return 1
@@ -169,15 +169,15 @@ bpkg_install () {
   for remote in "${BPKG_REMOTES[@]}"; do
     local git_remote=${BPKG_GIT_REMOTES[$i]}
     bpkg_install_from_remote "$pkg" "$remote" "$git_remote" $needs_global
-    if [ "$?" == "0" ]; then
+    if [ "$?" == '0' ]; then
       return 0
-    elif [ "$?" == "2" ]; then
-      error "fatal error occurred during install"
+    elif [ "$?" == '2' ]; then
+      error 'fatal error occurred during install'
       return 1
     fi
     i=$((i+1))
   done
-  error "package not found on any remote"
+  error 'package not found on any remote'
   return 1
 }
 
@@ -193,15 +193,15 @@ bpkg_install_from_remote () {
   local let needs_global=$4
 
   local cwd=$(pwd)
-  local url=""
-  local uri=""
-  local version=""
-  local status=""
-  local json=""
-  local user=""
-  local name=""
-  local version=""
-  local auth_param=""
+  local url=''
+  local uri=''
+  local version=''
+  local status=''
+  local json=''
+  local user=''
+  local name=''
+  local version=''
+  local auth_param=''
   local let has_pkg_json=1
   declare -a local pkg_parts=()
   declare -a local remote_parts=()
@@ -217,13 +217,13 @@ bpkg_install_from_remote () {
   }
 
   if [ ${#pkg_parts[@]} -eq 1 ]; then
-    version="master"
+    version='master'
     #info "Using latest (master)"
   elif [ ${#pkg_parts[@]} -eq 2 ]; then
     name="${pkg_parts[0]}"
     version="${pkg_parts[1]}"
   else
-     error "Error parsing package version"
+     error 'Error parsing package version'
     return 1
   fi
 
@@ -242,7 +242,7 @@ bpkg_install_from_remote () {
     user="${pkg_parts[0]}"
     name="${pkg_parts[1]}"
   else
-    error "Unable to determine package name"
+    error 'Unable to determine package name'
     return 1
   fi
 
@@ -254,9 +254,9 @@ bpkg_install_from_remote () {
 
   ## check to see if remote is raw with oauth (GHE)
   if [ "${remote:0:10}" == "raw-oauth|" ]; then
-    info "Using OAUTH basic with content requests"
+    info 'Using OAUTH basic with content requests'
     OLDIFS="${IFS}"
-    IFS="|"
+    IFS="'|'"
     local remote_parts=($remote)
     IFS="${OLDIFS}"
     local token=${remote_parts[1]}
@@ -294,7 +294,7 @@ bpkg_install_from_remote () {
   ## determine if 'package.json' exists at url
   {
     if ! url_exists "${url}/package.json?$(date +%s)" "${auth_param}"; then
-      warn "package.json doesn't exist"
+      warn 'package.json doesn`t exist'
       has_pkg_json=0
       # check to see if there's a Makefile. If not, this is not a valid package
       if ! url_exists "${url}/Makefile?$(date +%s)" "${auth_param}"; then
@@ -362,9 +362,9 @@ bpkg_install_from_remote () {
     fi
 
     if [ -z "${build}" ]; then
-      warn "Missing build script"
-      warn "Trying \`make install'..."
-      build="make install"
+      warn 'Missing build script'
+      warn 'Trying `make install`...'
+      build='make install'
     fi
 
     { (
@@ -400,7 +400,7 @@ bpkg_install_from_remote () {
     # install package dependencies
     (cd "${cwd}/deps/${name}" && bpkg getdeps)
 
-    if [ "${#scripts[@]}" -gt "0" ]; then
+    if [ "${#scripts[@]}" -gt '0' ]; then
       ## grab each script and place in deps directory
       for (( i = 0; i < ${#scripts[@]} ; ++i )); do
         (
@@ -415,7 +415,7 @@ bpkg_install_from_remote () {
         )
       done
     fi
-    if [ "${#files[@]}" -gt "0" ]; then
+    if [ "${#files[@]}" -gt '0' ]; then
       ## grab each file
       for (( i = 0; i < ${#files[@]} ; ++i )); do
         (

--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -416,13 +416,15 @@ bpkg_install_from_remote () {
       for (( i = 0; i < ${#scripts[@]} ; ++i )); do
         (
           local script="$(echo ${scripts[$i]} | xargs basename )"
-          info "fetch" "${url}/${script}"
-          info "write" "${cwd}/deps/${name}/${script}"
-          save_remote_file "${url}/${script}" "${cwd}/deps/${name}/${script}" "${auth_param}"
-          local scriptname="${script%.*}"
-          info "${scriptname} to PATH" "${cwd}/deps/bin/${scriptname}"
-          ln -si "${cwd}/deps/${name}/${script}" "${cwd}/deps/bin/${scriptname}"
-          chmod u+x "${cwd}/deps/bin/${scriptname}"
+          if [[ "${script}" ]];then
+            info "fetch" "${url}/${script}"
+            info "write" "${cwd}/deps/${name}/${script}"
+            save_remote_file "${url}/${script}" "${cwd}/deps/${name}/${script}" "${auth_param}"
+            local scriptname="${script%.*}"
+            info "${scriptname} to PATH" "${cwd}/deps/bin/${scriptname}"
+            ln -si "${cwd}/deps/${name}/${script}" "${cwd}/deps/bin/${scriptname}"
+            chmod u+x "${cwd}/deps/bin/${scriptname}"
+          fi
         )
       done
     fi
@@ -431,13 +433,15 @@ bpkg_install_from_remote () {
       for (( i = 0; i < ${#files[@]} ; ++i )); do
         (
           local file="${files[$i]}"
-          local filedir="$(dirname "${cwd}/deps/${name}/${file}")"
-          info "fetch" "${url}/${file}"
-          if [[ ! -d "${filedir}" ]]; then
-            mkdir -p "${filedir}"
+          if [[ "${file}" ]];then
+            local filedir="$(dirname "${cwd}/deps/${name}/${file}")"
+            info "fetch" "${url}/${file}"
+            if [[ ! -d "${filedir}" ]]; then
+              mkdir -p "${filedir}"
+            fi
+            info "write" "${filedir}/${file}"
+            save_remote_file "${url}/${script}" "${filedir}/${file}" "${auth_param}"
           fi
-          info "write" "${filedir}/${file}"
-          save_remote_file "${url}/${script}" "${filedir}/${file}" "${auth_param}"
         )
       done
     fi

--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -82,6 +82,17 @@ info () {
 }
 
 
+save_remote_file () {
+  local auth_param path url
+
+  url="${1}"
+  path="${2}"
+  auth_param="${3}"
+
+  gurl "${url}" "${auth_param}" '-L' "-o '${path}'"
+}
+
+
 url_exists () {
     local auth_param exists url
 
@@ -389,7 +400,7 @@ bpkg_install_from_remote () {
   ## perform local install otherwise
   else
     ## copy package.json over
-    gurl "${url}/package.json" "${auth_param}" '-L' "-o '${cwd}/deps/${name}/package.json'"
+    save_remote_file "${url}/package.json" "${cwd}/deps/${name}/package.json" "${auth_param}"
 
     ## make 'deps/' directory if possible
     mkdir -p "${cwd}/deps/${name}"
@@ -407,7 +418,7 @@ bpkg_install_from_remote () {
           local script="$(echo ${scripts[$i]} | xargs basename )"
           info "fetch" "${url}/${script}"
           info "write" "${cwd}/deps/${name}/${script}"
-          gurl "${url}/${script}" "${auth_param}" '-L' "-o '${cwd}/deps/${name}/${script}'"
+          save_remote_file "${url}/${script}" "${cwd}/deps/${name}/${script}" "${auth_param}"
           local scriptname="${script%.*}"
           info "${scriptname} to PATH" "${cwd}/deps/bin/${scriptname}"
           ln -si "${cwd}/deps/${name}/${script}" "${cwd}/deps/bin/${scriptname}"
@@ -426,7 +437,7 @@ bpkg_install_from_remote () {
             mkdir -p "${filedir}"
           fi
           info "write" "${filedir}/${file}"
-          gurl "${url}/${script}" "${auth_param}" '-L' "-o '${filedir}/${file}'"
+          save_remote_file "${url}/${script}" "${filedir}/${file}" "${auth_param}"
         )
       done
     fi

--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -89,7 +89,7 @@ save_remote_file () {
   path="${2}"
   auth_param="${3}"
 
-  gurl "${url}" "${auth_param}" '-L' "-o '${path}'"
+  gurl "${url}" "${auth_param}" '-L' '-o' "${path}"
 }
 
 
@@ -101,7 +101,7 @@ url_exists () {
 
     exists=0
 
-    status=$(gurl "${url}" "${auth_param}" '-L' '-w %{http_code}' '-o /dev/null')
+    status=$(gurl "${url}" "${auth_param}" '-L' '-w %{http_code}' '-o' '/dev/null')
     result="$?"
 
     # In some rare cases, curl will return CURLE_WRITE_ERROR (23) when writing


### PR DESCRIPTION
## Introduction

I was thinking about taking a stab at #53 but decided to make the relevant file more shellcheck compliant first (as suggested in issue #78).

## Suggested Changes

### Shellcheck Fixes

All occurrences of the following issues have been resolved:

- **SC1054**: You need a space after the '{'.
- **SC2004**: $ on variables in (( )) is unnecessary.
- **SC2034**: "variable" appears unused. Verify it or export it.
- **SC2046**: Quote this to prevent word splitting.
- **SC2068**: Double quote array expansions, otherwise they're like $* and break on spaces.
- **SC2086**: Double quote to prevent globbing and word splitting.
- **SC2116**: Useless echo? Instead of 'cmd $(echo foo)', just use 'cmd foo'.

### Other issues

Whilst  resolving shellcheck issues, I ran into two problems.

1. The call `curl "${auth_param}"` caused trouble when `auth_param` is empty (`=''`). This did not happen when there were no quotes around `auth_param`, that is to say, things accidentally worked.   
  To resolve this I added a wrapper for the three use-cases around curl  with a check and two variations of calling curl (one with and one without `auth_param`.
2. In some edge-cases the `-o /dev/null` will fail with a write error (curl error 23). However, failure to write to `/dev/null` is not an issue, as the HTTP status code is still viable. To resolve this I added a separate function for the "check url exists" logic and added the check there. 

If these two solutions do not cause any trouble, I do believe they are worth keeping as they are a good first step in de-duplicating some of the curl calls.

## Work for later

The following shellcheck issues are still present as I am unsure as how to resolve them:

- **SC2059**: Don't use variables in the printf format string. Use printf "..%s.." "$foo".
- **SC2030**: Modification of script is local (to subshell caused by (..) group).
- **SC2031**: script was modified in a subshell. That change might be lost.

I would suggest fixing those issues in a separate PR  to keep things moving.

I'll continue work on #53 on a separate branch and open a PR once this has been merged to `master`.