### PR TITLE
Adds missing null check

### DIFF
--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -415,7 +415,7 @@ bpkg_install_from_remote () {
     # install package dependencies
     (cd "${cwd}/deps/${name}" && bpkg getdeps)
 
-    if [[ "${#scripts[@]}" -gt '0' ]]; then
+    if [[ "${#scripts[@]}" -gt '0' && "${scripts}" != "" ]]; then
       ## grab each script and place in deps directory
       for (( i = 0; i < ${#scripts[@]} ; ++i )); do
         (


### PR DESCRIPTION
As explained in the ticket, the current check for the "$scripts" array in the install script does not take into account that the array may be `""`.

This merge request adds a check to make sure that the  is not empty.

This Fixes issue #82.
