### PR TITLE
checkout the right version in the cloned repository during install

### DIFF
--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -393,6 +393,7 @@ bpkg_install_from_remote () {
         (
       ## move into directory
       cd "${name}-${version}" &&
+      git checkout ${version} &&
         ## build
       info "Performing install: \`${build}'"
       build_output=$(eval "${build}")


### PR DESCRIPTION
I was trying to set up bpkg on a repo, working on a non master branch.
I didnt managed to install it with `bpkg install -g AdrieanKhisbe/resty@refactor` and it was complaining about no make install target.

after investigating, I found that for global install there was no checking out of the appropriate ref before to run the command. Here is the fix :)