### PR TITLE
Reintroduce Makefile that invokes setup.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+SETUP := ./setup.sh
+COMMANDS := install uninstall link unlink
+
+.PHONY: default
+default:
+	@echo "make: Nothing to make."
+	@echo "make: Try one of the following:"
+	@for c in $(COMMANDS); do printf '\t%s\n' "make $$c"; done
+
+$(COMMANDS):
+	@$(SETUP) $@
+


### PR DESCRIPTION
This PR reintroduces the `Makefile` removed in the past. It simply invokes `make_*` commands already defined in the `setup.sh` file, which makes this implementation quite easy.