### PR TITLE
Fixes for #95 and #96 (caused by accident in #81) and other bugs

### DIFF
--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -419,14 +419,16 @@ bpkg_install_from_remote () {
     (cd "${cwd}/deps/${name}" && bpkg getdeps)
 
     ## grab each script and place in deps directory
-    for script in $scripts; do
+    for script in "${scripts[@]}"; do
       (
-        local script="$(echo $script | xargs basename )"
         if [[ "${script}" ]];then
+          local scriptname="$(echo "${script}" | xargs basename )"
+
           info "fetch" "${url}/${script}"
           info "write" "${cwd}/deps/${name}/${script}"
           save_remote_file "${url}/${script}" "${cwd}/deps/${name}/${script}" "${auth_param}"
-          local scriptname="${script%.*}"
+
+          scriptname="${scriptname%.*}"
           info "${scriptname} to PATH" "${cwd}/deps/bin/${scriptname}"
           ln -si "${cwd}/deps/${name}/${script}" "${cwd}/deps/bin/${scriptname}"
           chmod u+x "${cwd}/deps/bin/${scriptname}"
@@ -435,18 +437,15 @@ bpkg_install_from_remote () {
     done
 
     if [[ "${#files[@]}" -gt '0' ]]; then
-      ## grab each file
-      for (( i = 0; i < ${#files[@]} ; ++i )); do
-        (
-          local file="${files[$i]}"
+      ## grab each file and place in correct directory
+      for file in "${files[@]}"; do
+      (
           if [[ "${file}" ]];then
-            local filedir="$(dirname "${cwd}/deps/${name}/${file}")"
+            local filename="$(echo "${file}" | xargs basename )"
+
             info "fetch" "${url}/${file}"
-            if [[ ! -d "${filedir}" ]]; then
-              mkdir -p "${filedir}"
-            fi
-            info "write" "${filedir}/${file}"
-            save_remote_file "${url}/${script}" "${filedir}/${file}" "${auth_param}"
+            info "write" "${cwd}/deps/${name}/${file}"
+            save_remote_file "${url}/${file}" "${cwd}/deps/${name}/${file}" "${auth_param}"
           fi
         )
       done

--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -341,7 +341,7 @@ bpkg_install_from_remote () {
     )"
 
     ## check if forced global
-    if [[ ! -z "$(echo -n "${json}" | bpkg-json -b | grep '\["global"\]' | awk '{ print $2 }' | tr -d '"')" ]]; then
+    if [[ "$(echo -n "${json}" | bpkg-json -b | grep '\["global"\]' | awk '{ print $2 }' | tr -d '"')" == 'true' ]]; then
       needs_global=1
     fi
 

--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -89,6 +89,13 @@ save_remote_file () {
   path="${2}"
   auth_param="${3:-}"
 
+  local dirname="$(dirname "${path}")"
+
+  # Make sure directory exists
+  if [[ ! -d "${dirname}" ]];then
+    mkdir -p  "${dirname}"
+  fi
+
   if [[ "${auth_param}" ]];then
     curl --silent -L -o "${path}" -u "${auth_param}" "${url}"
   else

--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -415,6 +415,7 @@ bpkg_install_from_remote () {
     mkdir -p "${cwd}/deps/bin"
 
     # install package dependencies
+    info "Install dependencies for ${name}"
     (cd "${cwd}/deps/${name}" && bpkg getdeps)
 
     ## grab each script and place in deps directory

--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -341,7 +341,7 @@ bpkg_install_from_remote () {
     )"
 
     ## check if forced global
-    if [[ ! -"z $(echo -n "${json}" | bpkg-json -b | grep '\["global"\]' | awk '{ print $2 }' | tr -d '"')" ]]; then
+    if [[ ! -z "$(echo -n "${json}" | bpkg-json -b | grep '\["global"\]' | awk '{ print $2 }' | tr -d '"')" ]]; then
       needs_global=1
     fi
 

--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -347,30 +347,24 @@ bpkg_install_from_remote () {
 
     ## construct scripts array
     {
-      scripts=$(echo -n "${json}" | bpkg-json -b | grep '\["scripts' | awk '{$1=""; print $0 }' | tr -d '"')
+      scripts=$(echo -n "${json}" | bpkg-json -b | grep '\["scripts' | awk '{ print $2 }' | tr -d '"')
+
+      ## create array by splitting on newline
       OLDIFS="${IFS}"
-
-      ## comma to space
-      IFS=','
-      scripts=("${scripts[@]}")
+      IFS=$'\n'
+      scripts=(${scripts[@]})
       IFS="${OLDIFS}"
-
-      ## account for existing space
-      scripts=("${scripts[@]}")
     }
 
     ## construct files array
     {
-      files=$(echo -n "${json}" | bpkg-json -b | grep '\["files' | awk '{$1=""; print $0 }' | tr -d '"')
+      files=$(echo -n "${json}" | bpkg-json -b | grep '\["files' | awk '{ print $2 }' | tr -d '"')
+
+      ## create array by splitting on newline
       OLDIFS="${IFS}"
-
-      ## comma to space
-      IFS=','
-      files=("${files[@]}")
+      IFS=$'\n'
+      files=(${files[@]})
       IFS="${OLDIFS}"
-
-      ## account for existing space
-      files=("${files[@]}")
     }
 
   fi


### PR DESCRIPTION
This PR fixes #95 and #96, which were unfortunately caused by changes from the cleanup in #81.

## Other bug-fixes

I also encountered other bugs, fixes are included:

- Fixes bug in `save_remote_file` function in `bpkg-install` that occurred if a save-path did not exists. The function now attempts to create the directory before trying to save a file to it. This fix allows for nested `files` and `script` entries from `package.json` to be properly downloaded.
- Fixes bug in `bpkg-install` global check. Even before my accidental breakage in #81, the check was broken. The bug occurred when a "global" section was present in a `packages.json` file but had a value other than `true`. Due to the logic of the check, such a package would then be marked for global install.
- Fixes bug in `bpkg-install` scripts download that occurred when scripts were not in the root of the package. The Github '404' text file was then downloaded.

## Other changes

- Changes logic to create array from JSON sections in `bpkg-install`. The was code that claimed to make `## comma to space` but the output of the JSON _does not contain_ any commas.
- Add message in `bpkg-install` clarifying sub-dependencies are being installed.

## Final points of concern

When reviewing the changes from #81, I came across [an edit that changes `IFS="|"` to `IFS="'|'"`](https://github.com/bpkg/bpkg/pull/81/files#diff-8c1aeb140103e4da6ddff0a92e6cf9b8R274). This looks like a mistake which could also spell trouble...

As I feel horrible for introducing these bugs, I think it might be wise to redirect any effort purely into creating tests for `bpkg` before any other efforts are made.

The validation logic I used to check the working of each version of the code (pre-breakage, post-breakage, fixed) can be found here: https://gist.github.com/Potherca/d9b5817de94a45fff6ed698c799b08f3
