### PR TITLE
package json name key parse fix

### DIFF
--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -334,7 +334,7 @@ bpkg_install_from_remote () {
     name="$(
       echo -n "${json}" |
       bpkg-json -b |
-      grep 'name' |
+      grep -m 1 'name' |
       awk '{ $1=""; print $0 }' |
       tr -d '\"' |
       tr -d ' '

--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -334,7 +334,7 @@ bpkg_install_from_remote () {
     name="$(
       echo -n "${json}" |
       bpkg-json -b |
-      grep -m 1 'name' |
+      grep -m 1 '"name"' |
       awk '{ $1=""; print $0 }' |
       tr -d '\"' |
       tr -d ' '


### PR DESCRIPTION
- fix problem when we have
package.json with:
``` "files": ["lib/name.sh"]```