### PR TITLE
[WIP] Add unit-tests for bpkg_utils

### DIFF
--- a/lib/utils/test/bpkg_error.bats
+++ b/lib/utils/test/bpkg_error.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+
+load "${PROJECT_ROOT}/test/test_setup.bash"
+
+# Load file under test
+load "$(dirname "${BATS_TEST_DIRNAME}")/utils.sh"
+
+@test "bpkg_error should call bpkg_message for a red error when called" {
+    # arrange
+    bpkg_message() { echo -n "$@" >&9; }
+
+    # act
+    bpkg_error
+
+    # assert
+    assert_equal "$(getMockContent)" 'red error'
+}
+
+@test "bpkg_error should pass the parameter on to bpkg_message when called with one parameter" {
+    # arrange
+    bpkg_message() { echo -n "$@" >&9; }
+
+    # act
+    bpkg_error 'foo bar baz'
+
+    # assert
+    assert_equal "$(getMockContent)" 'red error foo bar baz'
+}
+
+@test "bpkg_error should pass all parameters on to  bpkg_message when called with multiple parameters" {
+    # arrange
+    bpkg_message() { echo -n "$@" >&9; }
+
+    # act
+    bpkg_error 'foo' 'bar' 'baz'
+
+    # assert
+    assert_equal "$(getMockContent)" 'red error foo bar baz'
+}
+
+@test "bpkg_error should output to stderr when called" {
+    # arrange
+    bpkg_message() {
+        echo 'foo bar baz'
+    }
+
+    # act
+    bpkg_error 1>&7 2>&8
+
+    # assert
+    assert_equal "$(getStderrContent)" 'foo bar baz'
+}
+
+@test "bpkg_error should not output to stdout when called" {
+    # arrange
+    bpkg_message() {
+        echo 'foo bar baz'
+    }
+
+    # act
+    bpkg_error 1>&7 2>&8
+
+    # assert
+    assert_equal "$(getStdoutContent)" ''
+}

--- a/lib/utils/test/bpkg_info.bats
+++ b/lib/utils/test/bpkg_info.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+
+load "${PROJECT_ROOT}/test/test_setup.bash"
+
+# Load file under test
+load "$(dirname "${BATS_TEST_DIRNAME}")/utils.sh"
+
+@test "bpkg_info should call bpkg_message for a cyan info when called" {
+    # arrange
+    bpkg_message() { echo -n "$@" >&9; }
+
+    # act
+    bpkg_info
+
+    # assert
+    assert_equal "$(getMockContent)" 'cyan info'
+}
+
+@test "bpkg_info should pass the parameter on to  bpkg_message when called with one parameter" {
+    # arrange
+    bpkg_message() { echo -n "$@" >&9; }
+
+    # act
+    bpkg_info 'foo bar baz'
+
+    # assert
+    assert_equal "$(getMockContent)" 'cyan info foo bar baz'
+}
+
+@test "bpkg_info should pass its parameters on to bpkg_message when called with multiple parameters" {
+    # arrange
+    bpkg_message() { echo -n "$@" >&9; }
+
+    # act
+    bpkg_info 'foo' 'bar' 'baz'
+
+    # assert
+    assert_equal "$(getMockContent)" 'cyan foo bar baz'
+}
+
+@test "bpkg_info should use the first parameter as title bpkg_message when called with multiple parameters" {
+    # arrange
+    bpkg_message() { echo -n "$@" >&9; }
+
+    # act
+    bpkg_info 'foo' 'bar' 'baz'
+
+    # assert
+    assert_equal "$(getMockContent)" 'cyan foo bar baz'
+}
+
+@test "bpkg_info should output to stdout when called" {
+    # arrange
+    bpkg_message() {
+        echo 'foo bar baz'
+    }
+
+    # act
+    bpkg_info 1>&7 2>&8
+
+    # assert
+    assert_equal "$(getStdoutContent)" 'foo bar baz'
+}
+
+@test "bpkg_info should not output to stderr when called" {
+    # arrange
+    bpkg_message() {
+        echo 'foo bar baz'
+    }
+
+    # act
+    bpkg_info 1>&7 2>&8
+
+    # assert
+    assert_equal "$(getStderrContent)" ''
+}

--- a/lib/utils/test/bpkg_warn.bats
+++ b/lib/utils/test/bpkg_warn.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+
+load "${PROJECT_ROOT}/test/test_setup.bash"
+
+# Load file under test
+load "$(dirname "${BATS_TEST_DIRNAME}")/utils.sh"
+
+@test "bpkg_warn should call bpkg_message for a yellow warning when called" {
+    # arrange
+    bpkg_message() { echo -n "$@" >&9; }
+
+    # act
+    bpkg_warn
+
+    # assert
+    assert_equal "$(getMockContent)" 'yellow warn'
+}
+
+@test "bpkg_warn should pass the parameter on to  bpkg_message when called with one parameter" {
+    # arrange
+    bpkg_message() { echo -n "$@" >&9; }
+
+    # act
+    bpkg_warn 'foo bar baz'
+
+    # assert
+    assert_equal "$(getMockContent)" 'yellow warn foo bar baz'
+}
+
+@test "bpkg_warn should pass all parameters on to bpkg_message when called with multiple parameters" {
+    # arrange
+    bpkg_message() { echo -n "$@" >&9; }
+
+    # act
+    bpkg_warn 'foo' 'bar' 'baz'
+
+    # assert
+    assert_equal "$(getMockContent)" 'yellow warn foo bar baz'
+}
+
+@test "bpkg_warn should output to stderr when called" {
+    # arrange
+    bpkg_message() {
+        echo 'foo bar baz'
+    }
+
+    # act
+    bpkg_warn 1>&7 2>&8
+
+    # assert
+    assert_equal "$(getStderrContent)" 'foo bar baz'
+}
+
+@test "bpkg_warn should not output to stdout when called" {
+    # arrange
+    bpkg_message() {
+        echo 'foo bar baz'
+    }
+
+    # act
+    bpkg_warn 1>&7 2>&8
+
+    # assert
+    assert_equal "$(getStdoutContent)" ''
+}

--- a/test/test_setup.bash
+++ b/test/test_setup.bash
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Load test dependencies
+load "${PROJECT_ROOT}/vendor/bats-support/load.bash"
+load "${PROJECT_ROOT}/vendor/bats-assert/load.bash"
+
+setup() {
+    # File descriptor 9 is used in mock functions to store input in
+    # After the file descriptor has been created, the assigned file needs to be
+    # deleted so that `/dev/fd/9` can be used for reading elsewhere without the
+    # need to know which file was originally used.
+    local -r sFileDescriptor="$(mktemp --tmpdir="${BATS_TMPDIR}" bats-mock.XXXXXX)"
+    exec 9<> "${sFileDescriptor}"
+    rm "${sFileDescriptor}"
+
+    getMockContent() {
+        cat /dev/fd/9
+    }
+
+    local -r sStderrPath="$(mktemp --tmpdir="${BATS_TMPDIR}" bats-stderr.XXXXXX)"
+    exec 8<> "${sStderrPath}"
+    rm "${sStderrPath}"
+
+    getStderrContent() {
+        cat /dev/fd/8
+    }
+
+    local -r sStdoutPath="$(mktemp --tmpdir="${BATS_TMPDIR}" bats-stdout.XXXXXX)"
+    exec 7<> "${sStdoutPath}"
+    rm "${sStdoutPath}"
+
+    getStdoutContent() {
+        cat /dev/fd/7
+    }
+
+    export -f getMockContent
+    export -f getStderrContent
+    export -f getStdoutContent
+}
+
+teardown() {
+    # close file descriptor
+    exec 7>&-
+    exec 8>&-
+    exec 9>&-
+}


### PR DESCRIPTION
This MR adds unit-tests for all the functions in `bpkg-utils`.

Currently done:

- [X] bpkg_error
- [X] bpkg_info
- [ ] bpkg_initrc
- [ ] bpkg_message
- [ ] bpkg_select_raw_path
- [ ] bpkg_select_remote
- [ ] bpkg_validate
- [x] bpkg_warn
