### PR TITLE
Installation in $HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,15 +67,9 @@ To directly install `bpkg` from its source code you have to clone its repository
 ```sh
 $ git clone https://github.com/bpkg/bpkg.git
 $ cd bpkg
-$ ./setup.sh
-```
-
-Or in a directory with user write permission, like `$HOME/opt/bin`
-
-```sh
-$ git clone https://github.com/bpkg/bpkg.git
-$ cd bpkg
-$ PREFIX=$HOME/opt ./setup.sh
+$ ./setup.sh                             # Will install bpkg in $HOME/.local/bin
+$ sudo ./setup.sh                        # Will install bpkg in /usr/local/bin.
+$ PREFIX=/my/custom/directory ./setup.sh # Will install bpkg in a custom directory.
 ```
 
 ## Usage
@@ -84,9 +78,10 @@ You use `bpkg` by simply sending commands, pretty much like `npm` or `pip`.
 
 ### Installing packages
 
-Packages can either be global (on `/usr/local/bin`) or local (under `./deps`).
+Packages can either be global (on `/usr/local/bin` if installed as root or
+ `$HOME/.local/bin` otherwize) or local (under `./deps`).
 
-For example, here's a **global install** of the [term package][term]:
+For example, here's a **global install for the current user** of the [term package][term]:
 
 ```sh
 $ bpkg install term -g

--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -383,6 +383,15 @@ bpkg_install_from_remote () {
       build='make install'
     fi
 
+    if [ -z "$PREFIX" ]; then
+      if [ $USER == 'root' ]; then
+        PREFIX="/usr/local"
+      else
+        PREFIX="$HOME/.local"
+      fi
+      build="env PREFIX=$PREFIX $build"
+    fi
+      
     { (
       ## go to tmp dir
       cd "$( [[ ! -z "${TMPDIR}" ]] && echo "${TMPDIR}" || echo /tmp)" &&

--- a/setup.sh
+++ b/setup.sh
@@ -60,7 +60,13 @@ setup () {
 
 ## make targets
 BIN="bpkg"
-[ -z "$PREFIX" ] && PREFIX="/usr/local"
+if [ -z "$PREFIX" ]; then
+  if [ $USER == 'root' ]; then
+    PREFIX="/usr/local"
+  else
+    PREFIX="$HOME/.local"
+  fi
+fi
 
 # All 'bpkg' supported commands
 CMDS="json install package term suggest init utils update list show getdeps"


### PR DESCRIPTION
This PR installs bpkg and the packages installed **globally** in `/usr/local/bin` if run as root and in `$HOME/.local/bin` if run as a user.

As there is not test framework integrated, I checked the following cases:
 - [x] setup.sh 
 - [x] bpkg install bpkg -g
 - [x] bpkg install term -g
 - [x] sudo setup.sh 
 - [x] sudo bpkg install bpkg -g
 - [x] sudo bpkg install term -g

 The PREFIX value is passed as environment variable to the build command of packages.json or to make install