### PR TITLE
refactor(setup.sh): Use double-quotes and double bracket conditional compound

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -61,7 +61,7 @@ setup () {
 ## make targets
 BIN="bpkg"
 if [ -z "$PREFIX" ]; then
-  if [[ $USER == "root" ]]; then
+  if [ "$USER" == "root" ]; then
     PREFIX="/usr/local"
   else
     PREFIX="$HOME/.local"

--- a/setup.sh
+++ b/setup.sh
@@ -61,7 +61,7 @@ setup () {
 ## make targets
 BIN="bpkg"
 if [ -z "$PREFIX" ]; then
-  if [ $USER == 'root' ]; then
+  if [[ $USER == "root" ]]; then
     PREFIX="/usr/local"
   else
     PREFIX="$HOME/.local"


### PR DESCRIPTION
This PR addresses double bracket conditional compound command usage in the `setup.sh` script that was introduced in #117 
cc @seybi87