### PR TITLE
refactor(lib/install/install.sh): Use double-quotes and double bracket conditional compound

### DIFF
--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -384,7 +384,7 @@ bpkg_install_from_remote () {
     fi
 
     if [ -z "$PREFIX" ]; then
-      if [[ $USER == "root" ]]; then
+      if [ "$USER" == "root" ]; then
         PREFIX="/usr/local"
       else
         PREFIX="$HOME/.local"

--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -384,14 +384,14 @@ bpkg_install_from_remote () {
     fi
 
     if [ -z "$PREFIX" ]; then
-      if [ $USER == 'root' ]; then
+      if [[ $USER == "root" ]]; then
         PREFIX="/usr/local"
       else
         PREFIX="$HOME/.local"
       fi
       build="env PREFIX=$PREFIX $build"
     fi
-      
+
     { (
       ## go to tmp dir
       cd "$( [[ ! -z "${TMPDIR}" ]] && echo "${TMPDIR}" || echo /tmp)" &&


### PR DESCRIPTION
This PR addresses double bracket conditional compound command usage in the `lib/install/install.sh` script that was introduced in #117 
cc @seybi87