### PR TITLE
Add support for bpkg.json, next to package.json.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can install shell scripts globally (on `/usr/local/bin`) or use them on a _p
 	* [Packages With Dependencies](#packages-with-dependencies)
 	* [Retrieving package info](#retrieving-package-info)
 * [Package details](#package-details)
-* [package.json](#packagejson)
+* [bpkg.json](#bpkgjson)
 	* [name](#name)
 	* [version (optional)](#version-optional)
 	* [description](#description)
@@ -109,17 +109,16 @@ $ bpkg install jwerle/suggest.sh@0.0.1 -g
 
 **Note:** to do that the packages **must be tagged releases** on the repository.
 
-You can also *install packages without a `package.json`*.
+You can also *install packages without a `bpkg.json` (or `package.json`)*.
 As long as there is a `Makefile` in the repository it will try to invoke `make install` as long as the `-g` or `--global` flags are set when invoking `bpkg install`.
 
-For example you could install [git-standup](https://github.com/stephenmathieson/git-standup) with an omitted `package.json` because of the `Makefile` and the `install` target found in it.
+For example you could install [git-standup](https://github.com/stephenmathieson/git-standup) with an omitted `bpkg.json` (or `package.json`) because of the `Makefile` and the `install` target found in it.
 
 ```sh
 $ bpkg install stephenmathieson/git-standup -g
 
-    info: Using latest (master)
-    warn: Package doesn't exist
-    warn: Missing build script
+    warn: bpkg.json doesn`t exist
+    warn: package.json doesn`t exist
     warn: Trying `make install'...
     info: install: `make install'
 cp -f git-standup /usr/local/bin
@@ -157,11 +156,12 @@ $ bpkg package
 
 Here we lay down some info on the structure of a package.
 
-## package.json
+## bpkg.json
 
-Every package must have a file called `package.json`; it specifies package metadata on the [JSON format][json].
+Every package must have a file called `bpkg.json` (for backward-compatibility 
+`package.json` can also be used); it specifies package metadata on the [JSON format][json].
 
-Here's an example of a well-formed `package.json`:
+Here's an example of a well-formed `bpkg.json`:
 
 ```json
 {

--- a/lib/getdeps/getdeps.sh
+++ b/lib/getdeps/getdeps.sh
@@ -10,7 +10,11 @@ usage () {
 ## Read a package property
 bpkg_getdeps () {
   local cwd="$(pwd)"
-  local pkg="${cwd}/package.json"
+  local pkg
+  pkg="${cwd}/bpkg.json"
+  if ! test -f "${pkg}"; then
+    pkg="${cwd}/package.json"
+  fi
 
   ## parse flags
   case "$1" in
@@ -22,7 +26,7 @@ bpkg_getdeps () {
 
   ## ensure there is a package to read
   if ! test -f "${pkg}"; then
-    echo 2>&1 "error: Unable to find \`package.json' in $(pwd)"
+    echo 2>&1 "error: Unable to find 'bpkg.json' or 'package.json' in $(pwd)"
     return 1
   fi
 

--- a/lib/init/README.md
+++ b/lib/init/README.md
@@ -1,7 +1,7 @@
 bpkg-init
 =========
 
-Interactively generate a `package.json` for your [bpkg][bp]. Code, format,
+Interactively generate a `bpkg.json` for your [bpkg][bp]. Code, format,
 and instructions based heavily on [jwerle's][jw] [clib-init][cb].
 
 [bp]: https://github.com/bpkg/bpkg/
@@ -29,30 +29,30 @@ usage
 -----
 
 Simply invoke `bpkg init` and you wil be prompted with a series
-of questions about the generation of your `package.json`. Most options
+of questions about the generation of your `bpkg.json`. Most options
 have sane defaults.
 
-This will walk you through initializing the bpkg `package.json` file.
+This will walk you through initializing the bpkg `bpkg.json` file.
 It will prompt you for the bare minimum that is needed and provide
 defaults.
 
 See github.com/bpkg/bpkg for more information on defining the bpkg
-`package.json` file.
+`bpkg.json` file.
 
-You can press `^C` anytime to quit this prompt. The `package.json` file
+You can press `^C` anytime to quit this prompt. The `bpkg.json` file
 will only be written upon completion.
 
 ```sh
 $ bpkg init
 
-This will walk you through initializing the bpkg `package.json` file.
+This will walk you through initializing the bpkg `bpkg.json` file.
 It will prompt you for the bare minimum that is needed and provide
 defaults.
 
 See github.com/bpkg/bpkg for more information on defining the bpkg
-`package.json` file.
+`bpkg.json` file.
 
-You can press ^C anytime to quit this prompt. The `package.json` file
+You can press ^C anytime to quit this prompt. The `bpkg.json` file
 will only be written upon completion.
 
 name: (bpkg-init)

--- a/lib/init/init.sh
+++ b/lib/init/init.sh
@@ -78,21 +78,21 @@ wrap () {
 
 intro () {
   echo
-  echo "This will walk you through initializing the bpkg \`package.json' file."
+  echo "This will walk you through initializing the 'bpkg.json' file."
   echo "It will prompt you for the bare minimum that is needed and provide"
   echo "defaults."
   echo
   echo "See github.com/bpkg/bpkg for more information on defining the bpkg"
-  echo "\`package.json' file."
+  echo "\`bpkg.json' file."
   echo
-  echo "You can press ^C anytime to quit this prompt. The \`package.json' file"
+  echo "You can press ^C anytime to quit this prompt. The 'bpkg.json' file"
   echo "will only be written upon completion."
   echo
 }
 
 options () {
   opt NAME "$(basename $(pwd))"
-  opt VERSION "0.0.1"
+  opt VERSION "0.1.0"
   opt DESCRIPTION ""
   opt GLOBAL ""
   opt INSTALL "install -b ${NAME}.sh \${PREFIX:-/usr/local}/bin/${NAME}"
@@ -195,7 +195,7 @@ validate () {
 ## if package file already exists, ensure user wants to clobber
 clobber () {
   if test -f "${file}"; then
-    prompt_if "A \`package.json' already exists. Would you like to replace it?" rm -f "${file}"
+    prompt_if "A 'bpkg.json' already exists. Would you like to replace it?" rm -f "${file}"
   fi
 }
 
@@ -270,10 +270,10 @@ create_repo () {
 
 ## main
 bpkg_init () {
-  local version="0.0.1"
+  local version="0.1.0"
   local cwd="$(pwd)"
   local buf="" ## output buffer
-  local file="${cwd}/package.json" ## output file
+  local file="${cwd}/bpkg.json" ## output file
   local arg="$1"
   shift
 

--- a/lib/init/package.json
+++ b/lib/init/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bpkg-init",
-  "version": "0.0.1",
-  "description": "Initialize a bpkg package.json",
+  "version": "0.1.0",
+  "description": "Initialize a bpkg.json",
   "global": "true",
   "install": "make install",
   "scripts": [

--- a/lib/package/package.sh
+++ b/lib/package/package.sh
@@ -11,7 +11,11 @@ usage () {
 bpkg_package () {
   local prop="${1}"
   local cwd="$(pwd)"
-  local pkg="${cwd}/package.json"
+  local pkg
+  pkg="${cwd}/bpkg.json"
+  if ! test -f "${pkg}"; then
+    pkg="${cwd}/package.json"
+  fi
 
   ## parse flags
   case "${prop}" in
@@ -23,7 +27,7 @@ bpkg_package () {
 
   ## ensure there is a package to read
   if ! test -f "${pkg}"; then
-    echo 2>&1 "error: Unable to find \`package.json' in $(pwd)"
+    echo 2>&1 "error: Unable to find 'bpkg.json' or 'package.json' in $(pwd)"
     return 1
   fi
 
@@ -35,7 +39,7 @@ bpkg_package () {
     }
   else
     ## show value for a specific property
-    ## in 'package.json'
+    ## in 'bpkg.json' or 'package.json'
     {
       cat "${pkg}" | bpkg-json -b | grep "${prop}" | awk '{ $1=""; printf $0 }'
       echo

--- a/lib/show/show.sh
+++ b/lib/show/show.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="0.0.1"
+VERSION="0.1.0"
 
 if ! type -f bpkg-utils &>/dev/null; then
   echo "error: bpkg-utils not found, aborting"
@@ -26,8 +26,8 @@ usage () {
   echo
   echo "Commands:"
   echo "  readme        Print package README.md file, if available, suppressing other output"
-  echo "  sources       Print all sources listed in package.json scripts, in order. This"
-  echo "                option suppresses other output and prints executable bash."
+  echo "  sources       Print all sources listed in bpkg.json (or package.json) scripts, in "
+  echo "                order. This option suppresses other output and prints executable bash."
   echo
   echo "Options:"
   echo "  --help|-h     Print this help dialogue"
@@ -57,7 +57,10 @@ show_package () {
     uri=$BPKG_REMOTE/$pkg/raw/master
   fi
 
-  json=$(eval "curl $auth -sL '$uri/package.json?$(date +%s)'")
+  json=$(eval "curl $auth -sL '$uri/bpkg.json?$(date +%s)'")
+  if [ "${json}" = '404: Not Found' ];then
+    json=$(eval "curl $auth -sL '$uri/package.json?$(date +%s)'")
+  fi
   readme=$(eval "curl $auth -sL '$uri/README.md?$(date +%s)'")
 
   local readme_len=$(echo "$readme" | wc -l | tr -d ' ')


### PR DESCRIPTION
The changes in this MR allow for using a `bpkg.json` instead of a `package.json` file.

It has been implemented following the discussion and decision in #17.

Once merged this would close #17 and #100.

Instead of merging to the main branch, I have created a `develop` branch, so it can be tested before merging to master.

Once this MR has been reviewed, it can be merged to `develop`, after it has been sufficiently tested in the wild, it can be merged to master.