### PR TITLE
Fix unresolved branch in repository that use 'main'

### DIFF
--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -401,13 +401,18 @@ bpkg_install_from_remote () {
       info "Cloning ${repo_url} to ${name}-${version}"
       git clone "${repo_url}" "${name}-${version}" &&
         (
-      ## move into directory
-      cd "${name}-${version}" &&
-      git checkout ${version} &&
+        ## move into directory
+        cd "${name}-${version}" &&
+          (
+          ## checkout to branch version
+          git checkout ${version} ||
+          ## checkout into branch 'main' just in case 'master' was renamed
+          [ "${version}" = "master" ] && git checkout main
+          ) &&
         ## build
-      info "Performing install: \`${build}'"
-      build_output=$(eval "${build}")
-      echo "${build_output}"
+        info "Performing install: \`${build}'"
+        build_output=$(eval "${build}")
+        echo "${build_output}"
       ) &&
         ## clean up
       rm -rf "${name}-${version}"


### PR DESCRIPTION
Fix unresolved branch in repository that use 'main' instead of 'master' as default branch

At this moment we have strande behaviour with remote file discovery because GitHub redirect URL with 'master' branch into 'main'

Look this links 
- https://raw.githubusercontent.com/francescobianco/bpkg-template/main/Makefile
- https://raw.githubusercontent.com/francescobianco/bpkg-template/master/Makefile

Both exists but the real one is the FIRST the one with 'main'. This is a fall-back for master/main renaming phase.

The problem is related to the local clone of the repo in which is not possible to switch into 'master' branch because it dos not real exist.

- https://github.com/francescobianco/bpkg-template/branches

My strategy is simply: in case of checkout fails and i'm looking for 'master' then i checkout the 'main'



