### PR TITLE
Fix incorrect function export name.

### DIFF
--- a/lib/init/init.sh
+++ b/lib/init/init.sh
@@ -336,7 +336,7 @@ bpkg_init () {
 
 ## export or run
 if [[ ${BASH_SOURCE[0]} != "$0" ]]; then
-  export -f bpkg-init
+  export -f bpkg_init
 else
   bpkg_init "${@}"
   exit $?


### PR DESCRIPTION
The `bpkg-init` code exports the function delimited with a dash `-` but the function name contains an underscore `_` _not_ a dash.

This MR fixes that.