### PR TITLE
List Commands with Descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ You can install shell scripts globally (on `${PREFIX:-/usr/local/bin}`) or use t
     * [dependencies (optional)](#dependencies-optional)
     * [dependencies-dev (optional)](#dependencies-dev-optional)
     * [commands (optional)](#commands-optional)
+    * [commands-description (optional)](#commands-description-optional)
 * [Packaging best practices](#packaging-best-practices)
     * [Package exports](#package-exports)
 * [Sponsors](#sponsors)
@@ -287,6 +288,16 @@ The commands are run with `eval`, which runs the command as if on the command li
 ```bash
 $ bpkg run say-hello "Bash Package Manager"
 Hello Bash Package Manager
+```
+
+### commands-description (optional)
+
+This is a hash of descriptions for configured commands.  The keys are the names of the commands and the values are the descriptions for the specified commands.  The command descriptions can be listed on the command line by providing the `-l` or `--list` flags after the `bpkg run` command.
+
+```json
+  "commands-description": {
+    "say-hello": "Output hello to provided name (ex: bpkg run say-hello John)"
+  }
 ```
 
 ## Packaging best practices

--- a/README.md
+++ b/README.md
@@ -8,33 +8,33 @@ You can install shell scripts globally (on `${PREFIX:-/usr/local/bin}`) or use t
 
 <!-- BEGIN-MARKDOWN-TOC -->
 * [Install](#install)
-	* [0. Dependencies](#0-dependencies)
-	* [1. Install script](#1-install-script)
-	* [2. clib](#2-clib)
-	* [3. Source Code](#3-source-code)
+    * [0. Dependencies](#0-dependencies)
+    * [1. Install script](#1-install-script)
+    * [2. clib](#2-clib)
+    * [3. Source Code](#3-source-code)
 * [Usage](#usage)
-	* [Installing packages](#installing-packages)
-	* [Packages With Dependencies](#packages-with-dependencies)
-	* [Running packages with `bpkg`](#running-packages-with-bpkg)
-	* [Retrieving package info](#retrieving-package-info)
+    * [Installing packages](#installing-packages)
+    * [Packages With Dependencies](#packages-with-dependencies)
+    * [Running packages with `bpkg`](#running-packages-with-bpkg)
+    * [Retrieving package info](#retrieving-package-info)
 * [Package details](#package-details)
 * [bpkg.json](#bpkgjson)
-	* [name](#name)
-	* [version (optional)](#version-optional)
-	* [description](#description)
-	* [global](#global)
-	* [install](#install-1)
-	* [scripts](#scripts)
-	* [files (optional)](#files-optional)
-	* [dependencies (optional)](#dependencies-optional)
-	* [commands (optional)](#commands-optional)
+    * [name](#name)
+    * [version (optional)](#version-optional)
+    * [description](#description)
+    * [global](#global)
+    * [install](#install-1)
+    * [scripts](#scripts)
+    * [files (optional)](#files-optional)
+    * [dependencies (optional)](#dependencies-optional)
+    * [dependencies-dev (optional)](#dependencies-dev-optional)
+    * [commands (optional)](#commands-optional)
 * [Packaging best practices](#packaging-best-practices)
-	* [Package exports](#package-exports)
+    * [Package exports](#package-exports)
 * [Sponsors](#sponsors)
-	* [Contributors](#contributors)
-	* [Backers](#backers)
+    * [Contributors](#contributors)
+    * [Backers](#backers)
 * [License](#license)
-
 <!-- END-MARKDOWN-TOC -->
 
 ## Install
@@ -258,6 +258,16 @@ This is a hash of dependencies. The keys are the package names, and the values a
 
 ```json
   "dependencies": {
+    "term": "0.0.1"
+  }
+```
+
+### dependencies-dev (optional)
+
+This is a hash of dependencies only needed during development.  Like the `dependencies` array, the keys are the package names, and the values are the version specifiers; `'master'` or a tagged release can be used as the identifier. These development dependencies are installed by adding the `-d` or `--dev` flags to the `bpkg install` command.
+
+```json
+  "dependencies-dev": {
     "term": "0.0.1"
   }
 ```

--- a/bpkg.json
+++ b/bpkg.json
@@ -8,5 +8,9 @@
   "commands": {
     "lint": "command shellcheck **/*.sh",
     "list-sources": "echo ${BPKG_PACKAGE_SOURCES[@]} | sed 's/ /\n/g'"
+  },
+  "commands-description": {
+    "lint": "Execute shellcheck against all .sh files in project",
+    "list-sources": "Output package source files"
   }
 }

--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -1,31 +1,20 @@
 #!/usr/bin/env bash
 
-if ! type -f bpkg-realpath &>/dev/null; then
-  echo "error: bpkg-realpath not found, aborting"
-  exit 1
-else
-  # shellcheck disable=SC2230
-  # shellcheck source=lib/realpath/realpath.sh
-  source "$(which bpkg-realpath)"
-fi
-
 if ! type -f bpkg-utils &>/dev/null; then
   echo "error: bpkg-utils not found, aborting"
   exit 1
-else
-  # shellcheck disable=SC2230
-  # shellcheck source=lib/utils/utils.sh
-  source "$(which bpkg-utils)"
 fi
 
-if ! type -f bpkg-getdeps &>/dev/null; then
-  echo "error: bpkg-getdeps not found, aborting"
-  exit 1
-else
-  # shellcheck disable=SC2230
-  # shellcheck source=lib/getdeps/getdeps.sh
+# shellcheck source=lib/utils/utils.sh
+source "$(which bpkg-utils)"
+
+# shellcheck source=lib/realpath/realpath.sh
+bpkg_exec_or_exit bpkg-realpath &&
+  source "$(which bpkg-realpath)"
+
+# shellcheck source=lib/getdeps/getdeps.sh
+bpkg_exec_or_exit bpkg-getdeps &&
   source "$(which bpkg-getdeps)"
-fi
 
 bpkg_initrc
 

--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -23,15 +23,6 @@ let install_dev=0
 let force_actions=${BPKG_FORCE_ACTIONS:-0}
 let needs_global=0
 
-## check parameter consistency
-validate_parameters () {
-  if [[ ${#BPKG_GIT_REMOTES[@]} -ne ${#BPKG_REMOTES[@]} ]]; then
-    error "$(printf 'BPKG_GIT_REMOTES[%d] differs in size from BPKG_REMOTES[%d] array' "${#BPKG_GIT_REMOTES[@]}" "${#BPKG_REMOTES[@]}")"
-    return 1
-  fi
-  return 0
-}
-
 ## output usage
 usage () {
   echo 'usage: bpkg-install [directory]'
@@ -39,62 +30,6 @@ usage () {
   echo '   or: bpkg-install [-d|--dev]'
   echo '   or: bpkg-install [-g|--global] [-f|--force] ...<package>'
   echo '   or: bpkg-install [-g|--global] [-f|--force] ...<user>/<package>'
-}
-
-## format and output message
-message () {
-  if type -f bpkg-term > /dev/null 2>&1; then
-    bpkg-term color "$1"
-  fi
-
-  shift
-  echo -n "    $1"
-  shift
-
-  if type -f bpkg-term > /dev/null 2>&1; then
-    bpkg-term reset
-  fi
-
-  printf ': '
-
-  if type -f bpkg-term > /dev/null 2>&1; then
-    bpkg-term reset
-    bpkg-term bright
-  fi
-
-  printf "%s\n" "$@"
-
-  if type -f bpkg-term > /dev/null 2>&1; then
-    bpkg-term reset
-  fi
-}
-
-## output error
-error () {
-  message 'red' 'error' "$@" >&2
-
-  return 0
-}
-
-## output warning
-warn () {
-  message 'yellow' 'warn' "$@" >&2
-
-  return 0
-}
-
-## output info
-info () {
-  local title='info'
-
-  if (( "$#" > 1 )); then
-    title="$1"
-    shift
-  fi
-
-  message 'cyan' "$title" "$@"
-
-  return 0
 }
 
 save_remote_file () {
@@ -198,7 +133,7 @@ bpkg_install () {
           pkgs+=("$opt")
           shift
         else
-          error "Unknown option \`$opt'"
+          bpkg_error "Unknown option \`$opt'"
           return 1
         fi
         ;;
@@ -238,7 +173,7 @@ bpkg_install () {
         did_fail=0
         break
       elif [[ "$?" == '2' ]]; then
-        error 'fatal error occurred during install'
+        bpkg_error 'fatal error occurred during install'
         return 1
       fi
       i=$((i+1))
@@ -246,7 +181,7 @@ bpkg_install () {
   done
 
   if (( did_fail == 1 )); then
-    error 'package not found on any remote'
+    bpkg_error 'package not found on any remote'
     return 1
   fi
 
@@ -298,7 +233,7 @@ bpkg_install_from_remote () {
     name="${pkg_parts[0]}"
     version="${pkg_parts[1]}"
   else
-    error 'Error parsing package version'
+    bpkg_error 'Error parsing package version'
     return 1
   fi
 
@@ -318,7 +253,7 @@ bpkg_install_from_remote () {
     user="${pkg_parts[0]}"
     name="${pkg_parts[1]}"
   else
-    error 'Unable to determine package name'
+    bpkg_error 'Unable to determine package name'
     return 1
   fi
 
@@ -329,7 +264,7 @@ bpkg_install_from_remote () {
 
   ## check to see if remote is raw with oauth (GHE)
   if [[ "${remote:0:10}" == "raw-oauth|" ]]; then
-    info 'Using OAUTH basic with content requests'
+    bpkg_info 'Using OAUTH basic with content requests'
     OLDIFS="$IFS"
     IFS="'|'"
     local remote_parts=("$remote")
@@ -349,7 +284,7 @@ bpkg_install_from_remote () {
 
   ## clean up extra slashes in uri
   uri=${uri/\/\///}
-  info "Install $uri from remote $remote [$git_remote]"
+  bpkg_info "Install $uri from remote $remote [$git_remote]"
 
   ## Ensure remote is reachable
   ## If a remote is totally down, this will be considered a fatal
@@ -357,7 +292,7 @@ bpkg_install_from_remote () {
   ## from the broken remote.
   {
     if ! url_exists "$remote" "$auth_param"; then
-      error "Remote unreachable: $remote"
+      bpkg_error "Remote unreachable: $remote"
       return 2
     fi
   }
@@ -381,7 +316,7 @@ bpkg_install_from_remote () {
   if (( 0 == has_pkg_json )); then
     ## check to see if there's a Makefile. If not, this is not a valid package
     if ! url_exists "$url/Makefile?$nonce" "$auth_param"; then
-      warn "Makefile not found, skipping remote: $url"
+      bpkg_warn "Makefile not found, skipping remote: $url"
       return 1
     fi
   fi
@@ -451,8 +386,8 @@ bpkg_install_from_remote () {
     fi
 
     if [[ -z "$build" ]]; then
-      warn 'Missing build script'
-      warn 'Trying "make install"...'
+      bpkg_warn 'Missing build script'
+      bpkg_warn 'Trying "make install"...'
       build='make install'
     fi
 
@@ -472,7 +407,7 @@ bpkg_install_from_remote () {
       ( (( 0 == prevent_prune )) && rm -rf "$name-$version")
 
       ## shallow clone
-      info "Cloning $repo_url to $(pwd)/$name-$version"
+      bpkg_info "Cloning $repo_url to $(pwd)/$name-$version"
       (test -d "$name-$version" || git clone "$repo_url" "$name-$version" 2>/dev/null) && (
           ## move into directory
           cd "$name-$version" && (
@@ -484,7 +419,7 @@ bpkg_install_from_remote () {
           )
 
           ## build
-          info "Performing install: \`$build'"
+          bpkg_info "Performing install: \`$build'"
           mkdir -p "$PREFIX"/{bin,lib}
           build_output=$(eval "$build")
           echo "$build_output"
@@ -507,7 +442,7 @@ bpkg_install_from_remote () {
     mkdir -p "$BPKG_PACKAGE_DEPS/bin"
 
     # install package dependencies
-    info "Install dependencies for $name"
+    bpkg_info "Install dependencies for $name"
 
     BPKG_DEPS_EXEC="bpkg_getdeps"
     if (( 1 == install_dev )); then
@@ -522,19 +457,19 @@ bpkg_install_from_remote () {
         if [[ "$script" ]];then
           local scriptname="$(echo "$script" | xargs basename )"
 
-          info "fetch" "$url/$script"
-          warn "BPKG_PACKAGE_DEPS is '$BPKG_PACKAGE_DEPS'"
-          info "write" "$BPKG_PACKAGE_DEPS/$name/$script"
+          bpkg_info "fetch" "$url/$script"
+          bpkg_warn "BPKG_PACKAGE_DEPS is '$BPKG_PACKAGE_DEPS'"
+          bpkg_info "write" "$BPKG_PACKAGE_DEPS/$name/$script"
           save_remote_file "$url/$script" "$BPKG_PACKAGE_DEPS/$name/$script" "$auth_param"
 
           scriptname="${scriptname%.*}"
-          info "$scriptname to PATH" "$BPKG_PACKAGE_DEPS/bin/$scriptname"
+          bpkg_info "$scriptname to PATH" "$BPKG_PACKAGE_DEPS/bin/$scriptname"
 
           if (( force_actions == 1 )); then
             ln -sf "../$name/$script" "$BPKG_PACKAGE_DEPS/bin/$scriptname"
           else
             if test -f "$BPKG_PACKAGE_DEPS/bin/$scriptname"; then
-              warn "'$BPKG_PACKAGE_DEPS/bin/$scriptname' already exists. Overwrite? (yN)"
+              bpkg_warn "'$BPKG_PACKAGE_DEPS/bin/$scriptname' already exists. Overwrite? (yN)"
               read -r yn
               case $yn in
                 Yy) rm -f "$BPKG_PACKAGE_DEPS/bin/$scriptname" ;;
@@ -554,9 +489,9 @@ bpkg_install_from_remote () {
       for file in "${files[@]}"; do
       (
           if [[ "$file" ]];then
-            info "fetch" "$url/$file"
-            warn "BPKG_PACKAGE_DEPS is '$BPKG_PACKAGE_DEPS'"
-            info "write" "$BPKG_PACKAGE_DEPS/$name/$file"
+            bpkg_info "fetch" "$url/$file"
+            bpkg_warn "BPKG_PACKAGE_DEPS is '$BPKG_PACKAGE_DEPS'"
+            bpkg_info "write" "$BPKG_PACKAGE_DEPS/$name/$file"
             save_remote_file "$url/$file" "$BPKG_PACKAGE_DEPS/$name/$file" "$auth_param"
           fi
         )
@@ -569,7 +504,7 @@ bpkg_install_from_remote () {
 ## Use as lib or perform install
 if [[ ${BASH_SOURCE[0]} != "$0" ]]; then
   export -f bpkg_install
-elif validate_parameters; then
+elif bpkg_validate; then
   bpkg_install "$@"
   exit $?
 else

--- a/lib/list/list.sh
+++ b/lib/list/list.sh
@@ -3,10 +3,10 @@
 if ! type -f bpkg-utils &>/dev/null; then
   echo "error: bpkg-utils not found, aborting"
   exit 1
-else
-  # shellcheck source=lib/utils/utils.sh
-  source "$(which bpkg-utils)"
 fi
+
+# shellcheck source=lib/utils/utils.sh
+source "$(which bpkg-utils)"
 
 bpkg_initrc
 

--- a/lib/package/package.sh
+++ b/lib/package/package.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
 
-if ! type -f bpkg-realpath &>/dev/null; then
-  echo "error: bpkg-realpath not found, aborting"
+if ! type -f bpkg-utils &>/dev/null; then
+  echo "error: bpkg-utils not found, aborting"
   exit 1
-else
-  # shellcheck disable=SC2230
-  # shellcheck source=lib/realpath/realpath.sh
-  source "$(which bpkg-realpath)"
 fi
+
+# shellcheck source=lib/utils/utils.sh
+source "$(which bpkg-utils)"
+
+# shellcheck source=lib/realpath/realpath.sh
+bpkg_exec_or_exit bpkg-realpath &&
+  source "$(which bpkg-realpath)"
 
 BPKG_JSON="$(which bpkg-json)"
 

--- a/lib/run/run.sh
+++ b/lib/run/run.sh
@@ -1,46 +1,26 @@
 #!/usr/bin/env bash
 
-if ! type -f bpkg-realpath &>/dev/null; then
-  echo "error: bpkg-realpath not found, aborting"
-  exit 1
-else
-  # shellcheck disable=SC2230
-  # shellcheck source=lib/realpath/realpath.sh
-  source "$(which bpkg-realpath)"
-fi
+# shellcheck disable=SC2230 # which is non-standard. Use builtin command -v instead.
 
 if ! type -f bpkg-utils &>/dev/null; then
   echo "error: bpkg-utils not found, aborting"
   exit 1
-else
-  # shellcheck source=lib/utils/utils.sh
-  source "$(which bpkg-utils)"
 fi
 
-if ! type -f bpkg-env &>/dev/null; then
-  echo "error: bpkg-env not found, aborting"
-  exit 1
-else
-  # shellcheck disable=SC2230
-  # shellcheck source=lib/env/env.sh
-  source "$(which bpkg-env)"
-fi
+# shellcheck source=lib/utils/utils.sh
+source "$(which bpkg-utils)"
 
-if ! type -f bpkg-install &>/dev/null; then
-  echo "error: bpkg-install not found, aborting"
-  exit 1
-else
-  # shellcheck source=lib/install/install.sh
+# shellcheck source=lib/realpath/realpath.sh
+bpkg_exec_or_exit bpkg-realpath &&
+  source "$(which bpkg-realpath)"
+
+# shellcheck source=lib/install/install.sh
+bpkg_exec_or_exit bpkg-install &&
   source "$(which bpkg-install)"
-fi
 
-if ! type -f bpkg-package &>/dev/null; then
-  echo "error: bpkg-package not found, aborting"
-  exit 1
-else
-  # shellcheck source=lib/package/package.sh
+# shellcheck source=lib/package/package.sh
+bpkg_exec_or_exit bpkg-package &&
   source "$(which bpkg-package)"
-fi
 
 bpkg_initrc
 

--- a/lib/run/run.sh
+++ b/lib/run/run.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-# shellcheck disable=SC2230 # which is non-standard. Use builtin command -v instead.
-
 if ! type -f bpkg-utils &>/dev/null; then
   echo "error: bpkg-utils not found, aborting"
   exit 1
@@ -32,11 +30,11 @@ usage () {
   echo '   or: bpkg-run [-s|--source] <user>/<package> [command]'
 }
 
-runner () {
+bpkg_runner () {
   local cmd="$1"
-  shift
-  # shellcheck disable=SC2068
+
   eval "$cmd"
+
   return $?
 }
 
@@ -117,8 +115,7 @@ bpkg_run () {
       done
 
       shift
-      # shellcheck disable=SC2068
-      runner "$prefix ${args[*]}" $@
+      bpkg_runner "$prefix ${args[*]}"
       return $?
     fi
   fi
@@ -152,9 +149,9 @@ bpkg_run () {
     return 1
   fi
 
-  local pkgname="$(bpkg_package name 2>/dev/null)"
-  if [ -n "$pkgname" ]; then
-    name="$pkgname"
+  local pkg_name="$(bpkg_package name 2>/dev/null)"
+  if [ -n "$pkg_name" ]; then
+    name="$pkg_name"
   fi
 
   if (( 1 == should_emit_source )); then
@@ -198,8 +195,7 @@ bpkg_run () {
         done
 
         shift
-        # shellcheck disable=SC2068
-        runner "$prefix ${args[*]}" $@
+        bpkg_runner "$prefix ${args[*]}"
       fi
 
       # shellcheck disable=SC2068

--- a/lib/run/run.sh
+++ b/lib/run/run.sh
@@ -39,7 +39,7 @@ bpkg_list_commands () {
 
   col_len="$(wc -L <<< "${commands}")"
 
-  if (( ${col_len} == 0 )); then
+  if [ "${col_len}" -eq 0 ]; then
     bpkg_error "No commands provided in BPKG package file."
     return 1
   fi

--- a/lib/show/show.sh
+++ b/lib/show/show.sh
@@ -3,19 +3,10 @@
 if ! type -f bpkg-utils &>/dev/null; then
   echo "error: bpkg-utils not found, aborting"
   exit 1
-else
-  # shellcheck source=lib/utils/utils.sh
-  source "$(which bpkg-utils)"
 fi
 
-if ! type -f bpkg-env &>/dev/null; then
-  echo "error: bpkg-env not found, aborting"
-  exit 1
-else
-  # shellcheck disable=SC2230
-  # shellcheck source=lib/env/env.sh
-  source "$(which bpkg-env)"
-fi
+# shellcheck source=lib/utils/utils.sh
+source "$(which bpkg-utils)"
 
 bpkg_initrc
 

--- a/lib/source/source.sh
+++ b/lib/source/source.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 
-if ! type -f bpkg-run &>/dev/null; then
-  echo "error: bpkg-run not found, aborting"
+if ! type -f bpkg-utils &>/dev/null; then
+  echo "error: bpkg-utils not found, aborting"
   exit 1
-else
-  # shellcheck source=lib/run/run.sh
-  source "$(which bpkg-run)"
 fi
+
+# shellcheck source=lib/utils/utils.sh
+source "$(which bpkg-utils)"
+
+# shellcheck source=lib/run/run.sh
+bpkg_exec_or_exit bpkg-run &&
+  source "$(which bpkg-run)"
+
 
 bpkg_source () {
   # shellcheck disable=SC2068

--- a/lib/suggest/suggest.sh
+++ b/lib/suggest/suggest.sh
@@ -3,11 +3,10 @@
 if ! type -f bpkg-utils &>/dev/null; then
   echo "error: bpkg-utils not found, aborting"
   exit 1
-else
-  # shellcheck disable=SC2230
-  # shellcheck source=lib/utils/utils.sh
-  source "$(which bpkg-utils)"
 fi
+
+# shellcheck source=lib/utils/utils.sh
+source "$(which bpkg-utils)"
 
 ## output usage
 usage () {

--- a/lib/update/update.sh
+++ b/lib/update/update.sh
@@ -3,10 +3,10 @@
 if ! type -f bpkg-utils &>/dev/null; then
   echo "error: bpkg-utils not found, aborting"
   exit 1
-else
-  # shellcheck source=lib/utils/utils.sh
-  source "$(which bpkg-utils)"
 fi
+
+# shellcheck source=lib/utils/utils.sh
+source "$(which bpkg-utils)"
 
 bpkg_initrc
 

--- a/lib/utils/utils.sh
+++ b/lib/utils/utils.sh
@@ -1,161 +1,185 @@
 #!/usr/bin/env bash
 
-if ! type -f bpkg-env &>/dev/null; then
-  echo "error: bpkg-env not found, aborting"
-  exit 1
-else
+if [ -z "${BPKG_UTILS}" ]; then
+  BPKG_UTILS=1
+
+  ## Collection of shared bpkg functions
+
+  ## Init local config and set environmental defaults
+  bpkg_initrc () {
+    local global_config=${BPKG_GLOBAL_CONFIG:-"/etc/bpkgrc"}
+    # shellcheck disable=SC1090
+    [ -f "$global_config" ] && source "$global_config"
+    local config=${BPKG_CONFIG:-"$HOME/.bpkgrc"}
+    # shellcheck disable=SC1090
+    [ -f "$config" ] && source "$config"
+    ## set defaults
+    if [ ${#BPKG_REMOTES[@]} -eq 0 ]; then
+      BPKG_REMOTES[0]=${BPKG_REMOTE-https://raw.githubusercontent.com}
+      BPKG_GIT_REMOTES[0]=${BPKG_GIT_REMOTE-https://github.com}
+
+      export BPKG_REMOTES
+      export BPKG_GIT_REMOTE
+      export BPKG_GIT_REMOTES
+    fi
+
+    export BPKG_PACKAGE_USER="${BPKG_PACKAGE_USER:-"bpkg"}"
+    export BPKG_INDEX=${BPKG_INDEX:-"$HOME/.bpkg/index"}
+
+    bpkg_validate
+
+    return $?
+  }
+
+  ## check parameter consistency
+  bpkg_validate () {
+    if [ ${#BPKG_GIT_REMOTES[@]} -ne ${#BPKG_REMOTES[@]} ]; then
+      bpkg_error "$(printf 'BPKG_GIT_REMOTES[%d] differs in size from BPKG_REMOTES[%d] array' "${#BPKG_GIT_REMOTES[@]}" "${#BPKG_REMOTES[@]}")"
+      return 1
+    fi
+    return 0
+  }
+
+
+  ## format and output message
+  bpkg_message () {
+    bpkg_exec_exist bpkg-term &&
+      bpkg-term color "${1}"
+    shift
+
+    echo -n "    ${1}"
+    shift
+
+    bpkg_exec_exist bpkg-term &&
+      bpkg-term reset
+
+    printf ": "
+
+    bpkg_exec_exist bpkg-term && {
+      bpkg-term reset
+      bpkg-term bright
+    }
+
+    printf "%s\n" "${@}"
+
+    bpkg_exec_exist bpkg-term &&
+      bpkg-term reset
+  }
+
+  ## output error
+  bpkg_error () {
+    {
+      bpkg_message "red" "error" "${@}"
+    } >&2
+  }
+
+  ## output warning
+  bpkg_warn () {
+    {
+      bpkg_message "yellow" "warn" "${@}"
+    } >&2
+  }
+
+  ## output info
+  bpkg_info () {
+    local title="info"
+    if (( "${#}" > 1 )); then
+      title="${1}"
+      shift
+    fi
+    bpkg_message "cyan" "${title}" "${@}"
+  }
+
+
+  ## check if executable exists in path
+  bpkg_exec_exist () {
+    local exec_name="${1}"
+
+    type -f "${exec_name}" > /dev/null 2>&1
+  }
+
+  ## executable exists in path or exit with message
+  bpkg_exec_or_exit () {
+    local exec_name="${1}"
+    local exit_error="${2:-1}"
+
+    if ! bpkg_exec_exist "${exec_name}"; then
+      bpkg_error "${exec_name} not found, aborting"
+      exit "${exit_error}"
+    fi
+  }
+
+
+  ## takes a remote and git-remote and sets the globals:
+  ##  BPKG_REMOTE: raw remote URI
+  ##  BPKG_GIT_REMOTE: git remote for cloning
+  ##  BPKG_AUTH_GIT_REMOTE: git remote with oauth info embedded,
+  ##  BPKG_OAUTH_TOKEN: token for x-oauth-basic
+  ##  BPKG_CURL_AUTH_PARAM: auth arguments for raw curl requests
+  ##  BPKG_REMOTE_INDEX: location of local index for remote
+  bpkg_select_remote () {
+    local remote=$1
+    local git_remote=$2
+    export BPKG_REMOTE_HOST=$(echo "$git_remote" | sed 's/.*:\/\///' | sed 's/\/$//' | tr '/' '_')
+    export BPKG_REMOTE_INDEX="$BPKG_INDEX/$BPKG_REMOTE_HOST"
+    # shellcheck disable=SC2034
+    export BPKG_REMOTE_INDEX_FILE="$BPKG_REMOTE_INDEX/index.txt"
+    export BPKG_OAUTH_TOKEN=""
+    export BPKG_CURL_AUTH_PARAM=""
+    export BPKG_GIT_REMOTE=$git_remote
+    export BPKG_AUTH_GIT_REMOTE=$git_remote
+    if [ "${remote:0:10}" == "raw-oauth|" ]; then
+      OLDIFS="${IFS}"
+      IFS="|"
+      # shellcheck disable=SC2206
+      local remote_parts=($remote)
+      IFS="${OLDIFS}"
+      export BPKG_OAUTH_TOKEN=${remote_parts[1]}
+      # shellcheck disable=SC2034
+      export BPKG_CURL_AUTH_PARAM="-u $BPKG_OAUTH_TOKEN:x-oauth-basic"
+      export BPKG_REMOTE=${remote_parts[2]}
+      if [[ "$git_remote" == https://* ]] && [[ "$git_remote" != *x-oauth-basic* ]] && [[ "$git_remote" != *${BPKG_OAUTH_TOKEN}* ]]; then
+        # shellcheck disable=SC2034
+        export BPKG_AUTH_GIT_REMOTE=${git_remote/https:\/\//https:\/\/$BPKG_OAUTH_TOKEN:x-oauth-basic@}
+      fi
+    else
+      export BPKG_REMOTE="$remote"
+    fi
+  }
+
+  ## given a user and name, sets BPKG_REMOTE_RAW_PATH using the available
+  ## BPKG_REMOTE and BPKG_OAUTH_TOKEN details
+  bpkg_select_raw_path () {
+    local user=$1
+    local name=$2
+    if [ "$BPKG_OAUTH_TOKEN" == "" ]; then
+      export BPKG_REMOTE_RAW_PATH="$BPKG_REMOTE/$user/$name"
+    else
+      # shellcheck disable=SC2034
+      Export BPKG_REMOTE_RAW_PATH="$BPKG_REMOTE/$user/$name/raw"
+    fi
+    return 0
+  }
+
+
+  bpkg_exec_or_exit bpkg-env
+
   # shellcheck disable=SC2230
   # shellcheck source=lib/env/env.sh
   source "$(which bpkg-env)"
+
+
+  export -f bpkg_initrc
+  export -f bpkg_validate
+
+  export -f bpkg_message
+  export -f bpkg_warn
+  export -f bpkg_error
+  export -f bpkg_info
+
+  export -f bpkg_exec_exist
+  export -f bpkg_exec_or_exit
+
+  export -f bpkg_select_remote
+  export -f bpkg_select_raw_path
 fi
-
-## Collection of shared bpkg functions
-
-## Init local config and set environmental defaults
-bpkg_initrc() {
-  local global_config=${BPKG_GLOBAL_CONFIG:-"/etc/bpkgrc"}
-  # shellcheck disable=SC1090
-  [ -f "$global_config" ] && source "$global_config"
-  local config=${BPKG_CONFIG:-"$HOME/.bpkgrc"}
-  # shellcheck disable=SC1090
-  [ -f "$config" ] && source "$config"
-  ## set defaults
-  if [ ${#BPKG_REMOTES[@]} -eq 0 ]; then
-    BPKG_REMOTES[0]=${BPKG_REMOTE-https://raw.githubusercontent.com}
-    BPKG_GIT_REMOTES[0]=${BPKG_GIT_REMOTE-https://github.com}
-
-    export BPKG_REMOTES
-    export BPKG_GIT_REMOTE
-    export BPKG_GIT_REMOTES
-  fi
-
-  export BPKG_PACKAGE_USER="${BPKG_PACKAGE_USER:-"bpkg"}"
-  export BPKG_INDEX=${BPKG_INDEX:-"$HOME/.bpkg/index"}
-
-  bpkg_validate
-
-  return $?
-}
-
-## check parameter consistency
-bpkg_validate () {
-  if [ ${#BPKG_GIT_REMOTES[@]} -ne ${#BPKG_REMOTES[@]} ]; then
-    bpkg_error "$(printf 'BPKG_GIT_REMOTES[%d] differs in size from BPKG_REMOTES[%d] array' "${#BPKG_GIT_REMOTES[@]}" "${#BPKG_REMOTES[@]}")"
-    return 1
-  fi
-  return 0
-}
-
-## format and output message
-bpkg_message () {
-  if type -f bpkg-term > /dev/null 2>&1; then
-    bpkg-term color "${1}"
-  fi
-
-  shift
-  echo -n "    ${1}"
-  shift
-
-  if type -f bpkg-term > /dev/null 2>&1; then
-    bpkg-term reset
-  fi
-
-  printf ": "
-
-  if type -f bpkg-term > /dev/null 2>&1; then
-    bpkg-term reset
-    bpkg-term bright
-  fi
-
-  printf "%s\n" "${@}"
-
-  if type -f bpkg-term > /dev/null 2>&1; then
-    bpkg-term reset
-  fi
-}
-
-## output error
-bpkg_error () {
-  {
-    bpkg_message "red" "error" "${@}"
-  } >&2
-}
-
-## output warning
-bpkg_warn () {
-  {
-    bpkg_message "yellow" "warn" "${@}"
-  } >&2
-}
-
-## output info
-bpkg_info () {
-  local title="info"
-  if (( "${#}" > 1 )); then
-    title="${1}"
-    shift
-  fi
-  bpkg_message "cyan" "${title}" "${@}"
-}
-
-## takes a remote and git-remote and sets the globals:
-##  BPKG_REMOTE: raw remote URI
-##  BPKG_GIT_REMOTE: git remote for cloning
-##  BPKG_AUTH_GIT_REMOTE: git remote with oauth info embedded,
-##  BPKG_OAUTH_TOKEN: token for x-oauth-basic
-##  BPKG_CURL_AUTH_PARAM: auth arguments for raw curl requests
-##  BPKG_REMOTE_INDEX: location of local index for remote
-bpkg_select_remote () {
-  local remote=$1
-  local git_remote=$2
-  export BPKG_REMOTE_HOST=$(echo "$git_remote" | sed 's/.*:\/\///' | sed 's/\/$//' | tr '/' '_')
-  export BPKG_REMOTE_INDEX="$BPKG_INDEX/$BPKG_REMOTE_HOST"
-  # shellcheck disable=SC2034
-  export BPKG_REMOTE_INDEX_FILE="$BPKG_REMOTE_INDEX/index.txt"
-  export BPKG_OAUTH_TOKEN=""
-  export BPKG_CURL_AUTH_PARAM=""
-  export BPKG_GIT_REMOTE=$git_remote
-  export BPKG_AUTH_GIT_REMOTE=$git_remote
-  if [ "${remote:0:10}" == "raw-oauth|" ]; then
-    OLDIFS="${IFS}"
-    IFS="|"
-    # shellcheck disable=SC2206
-    local remote_parts=($remote)
-    IFS="${OLDIFS}"
-    export BPKG_OAUTH_TOKEN=${remote_parts[1]}
-    # shellcheck disable=SC2034
-    export BPKG_CURL_AUTH_PARAM="-u $BPKG_OAUTH_TOKEN:x-oauth-basic"
-    export BPKG_REMOTE=${remote_parts[2]}
-    if [[ "$git_remote" == https://* ]] && [[ "$git_remote" != *x-oauth-basic* ]] && [[ "$git_remote" != *${BPKG_OAUTH_TOKEN}* ]]; then
-      # shellcheck disable=SC2034
-      export BPKG_AUTH_GIT_REMOTE=${git_remote/https:\/\//https:\/\/$BPKG_OAUTH_TOKEN:x-oauth-basic@}
-    fi
-  else
-    export BPKG_REMOTE="$remote"
-  fi
-}
-
-## given a user and name, sets BPKG_REMOTE_RAW_PATH using the available
-## BPKG_REMOTE and BPKG_OAUTH_TOKEN details
-bpkg_select_raw_path() {
-  local user=$1
-  local name=$2
-  if [ "$BPKG_OAUTH_TOKEN" == "" ]; then
-    export BPKG_REMOTE_RAW_PATH="$BPKG_REMOTE/$user/$name"
-  else
-    # shellcheck disable=SC2034
-    Export BPKG_REMOTE_RAW_PATH="$BPKG_REMOTE/$user/$name/raw"
-  fi
-  return 0
-}
-
-export -f bpkg_initrc
-export -f bpkg_validate
-
-export -f bpkg_message
-export -f bpkg_warn
-export -f bpkg_error
-export -f bpkg_info
-
-export -f bpkg_select_remote
-export -f bpkg_select_raw_path


### PR DESCRIPTION
A noticeable missing functionality is the ability to list the configured commands with the utility.  With this feature, a description of said commands would be helpful.  I've added a `commands-description` section to the configuration, as well as a `-l` and `--list` option to the BPKG `run` sub-command.  I've updated the README to include a section on the new configuration.