### PR TITLE
Fix run, when passing parameters to command.

### DIFF
--- a/lib/run/run.sh
+++ b/lib/run/run.sh
@@ -73,6 +73,7 @@ bpkg_list_commands () {
 
 bpkg_runner () {
   local cmd="$1"
+  shift
 
   eval "$cmd"
 
@@ -161,7 +162,7 @@ bpkg_run () {
       done
 
       shift
-      bpkg_runner "$prefix ${args[*]}"
+      bpkg_runner "$prefix ${args[*]}" "$@"
       return $?
     fi
   fi
@@ -241,7 +242,7 @@ bpkg_run () {
         done
 
         shift
-        bpkg_runner "$prefix ${args[*]}"
+        bpkg_runner "$prefix ${args[*]}" "$@"
       fi
 
       # shellcheck disable=SC2068


### PR DESCRIPTION
A bug was introduced in the previous PR.

The following examples are with a BPKG configured command named `test` with the following string:

```bash
echo $@
```

When running a command specified in the BPKG project file, the configured command was being passed as the only parameter:

```bash
bpkg run test 1 2 3 A B C
echo $@
```

Fixing that, found that none of the additional parameters were being passed.

```bash
bpkg run test 1 2 3 A B C

```

Repairing that the output was corrected:

```bash
bpkg run test 1 2 3 A B C
1 2 3 A B C
```