### PR TITLE
fix: Improve parsing of JSON strings

### DIFF
--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -164,7 +164,7 @@ bpkg_install () {
       did_fail=0
       continue
     fi
-
+    
     ## Check each remote in order
     local i=0
     for remote in "${BPKG_REMOTES[@]}"; do
@@ -381,8 +381,9 @@ bpkg_install_from_remote () {
   if (( 1 == needs_global )); then
     if (( has_pkg_json > 0 )); then
       ## install bin if needed
-      build="$(echo -n "$json" | bpkg-json -b | grep '\["install"\]' | awk '{$1=""; print $0 }' | tr -d '\"')"
-      build="$(echo -n "$build" | sed -e 's/^ *//' -e 's/ *$//')"
+      build="$(echo -n "$json" | bpkg-json -b -f='"install"')"
+      build=${build#\"}
+      build=${build%\"}
     fi
 
     if [[ -z "$build" ]]; then

--- a/lib/json/JSON.sh
+++ b/lib/json/JSON.sh
@@ -8,16 +8,34 @@ throw () {
 BRIEF=0
 LEAFONLY=0
 PRUNE=0
+FILTER=
 
 usage() {
   echo
-  echo "Usage: JSON.sh [-b] [-l] [-p] [-h]"
+  echo "Usage: JSON.sh [-b] [-l] [-p] [-f=<filter>] [-h]"
   echo
   echo "-p - Prune empty. Exclude fields with empty values."
   echo "-l - Leaf only. Only show leaf nodes, which stops data duplication."
   echo "-b - Brief. Combines 'Leaf only' and 'Prune empty' options."
+  echo "-f - Filter. Only print the values for the keys that match the specified filter"
   echo "-h - This help text."
   echo
+}
+
+escape_string() {
+    local str=$1
+
+    str=${str//\\\"/\"}
+    str=${str//\\\\/\\}
+    str=${str//\\\//\/}
+    str=${str//\\b/$'\b'}
+    str=${str//\\f/$'\f'}
+    str=${str//\\n/$'\n'}
+    str=${str//\\r/$'\r'}
+    str=${str//\\t/$'\t'}
+    # TODO: unicode escaping
+
+    REPLY=$str
 }
 
 parse_options() {
@@ -36,6 +54,8 @@ parse_options() {
       -l) LEAFONLY=1
       ;;
       -p) PRUNE=1
+      ;;
+      -f=*) FILTER=${1#-f=}
       ;;
       ?*) echo "ERROR: Unknown option."
           usage
@@ -126,7 +146,7 @@ parse_object () {
       while :
       do
         case "$token" in
-          '"'*'"') key=$token ;;
+          '"'*'"') escape_string "$token"; key=$REPLY ;;
           *) throw "EXPECTED string GOT ${token:-EOF}" ;;
         esac
         read -r token
@@ -158,7 +178,7 @@ parse_value () {
     '[') parse_array  "$jpath" ;;
     # At this point, the only valid single-character tokens are digits.
     ''|[!0-9]) throw "EXPECTED value GOT ${token:-EOF}" ;;
-    *) value=$token
+    *) escape_string "$token"; value=$REPLY
        isleaf=1
        [ "$value" = '""' ] && isempty=1
        ;;
@@ -169,8 +189,17 @@ parse_value () {
   [ "$LEAFONLY" -eq 0 ] && [ "$PRUNE" -eq 1 ] && [ "$isempty" -eq 0 ] && print=1
   [ "$LEAFONLY" -eq 1 ] && [ "$isleaf" -eq 1 ] && \
     [ $PRUNE -eq 1 ] && [ $isempty -eq 0 ] && print=1
-  [ "$print" -eq 1 ] && printf "[%s]\t%s\n" "$jpath" "$value"
-  :
+
+  if [ "$print" -eq 1 ]; then
+    # FILTER
+    if [ -n "$FILTER" ]; then
+      if [ "$FILTER" = "$jpath" ]; then
+        printf '%s\n' "$value"
+      fi
+    else
+      printf "[%s]\t%s\n" "$jpath" "$value"
+    fi
+  fi
 }
 
 parse () {


### PR DESCRIPTION
When looking at [bpkg/asdf](https://github.com/bpkg/asdf), I noticed the `bpkg.json` didn't take into account the [`ASDF_DIR`](https://asdf-vm.com/manage/configuration.html#asdf-dir) environment variable. Upon adding it, I noticed an issue: if I added any double quotation marks, they would mysteriously disappear. I also noticed that the backslashes that escaped my double quotation marks were not removed by the JSON parser.

This fixes that by:
- Adding escaping logic whenever the JSON parser encounteres a non-array, non-object
- Adds a filter argument to `bpkg-json`, so it can _only_ print the value of the key. This is useful if the JSON value contains tabs or newlines
- Removes the `tr -d '\"'` in the pipeline, so quotations aren't stripped

With these changes, a `bpkg.json` of the following now works:

```json
{
  "name": "asdf",
  "repo": "asdf-vm/asdf",
  "version": "master",
  "description": "Extendable version manager with support for Ruby, Node.js, Elixir, Erlang & more",
  "global": "true",
  "install": "true; mkdir -p \"$HOME/.asdf\"     && cp -R * \"$HOME/.asdf/\" && echo ''; echo 'Add the following:'; echo '. \"$HOME/.asdf/asdf.sh\"'; echo '. \"$HOME/.asdf/completions/asdf.bash\"'; echo 'to your .bashrc (or .bash_profile) file and then launch new shell'"
}
```