### PR TITLE
fix: Improve message when installing no packages

### DIFF
--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -180,6 +180,11 @@ bpkg_install () {
     done
   done
 
+  if ((${#pkgs[@]} == 0)); then
+    bpkg_error 'no packages supplied'
+    return 1
+  fi
+
   if (( did_fail == 1 )); then
     bpkg_error 'package not found on any remote'
     return 1


### PR DESCRIPTION
When running `bpkg install` with no argument, I noticed that the program would mysterously exit, without telling the user anything. To improve the user experience, this tells the user that packages should have been supplied, as most package managers do.
