### PR TITLE
fix: Improve error reporting on failed git clone

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -52,7 +52,12 @@ setup () {
     rm -rf "$DEST"
 
     echo "  info: Fetching 'bpkg@$BRANCH'..."
-    git clone --depth=1 --branch "$BRANCH" "$REMOTE" "$DEST" > /dev/null 2>&1
+    if ! output=$(git clone --depth=1 --branch "$BRANCH" "$REMOTE" "$DEST" 2>&1); then
+      printf '%s\n' "  error: Failed to clone repository." >&2
+      printf '%s\n' "GIT ERROR OUTPUT:"
+      printf '%s\n' "$output"
+      exit 1
+    fi
     cd "$DEST" || exit
 
     echo "  info: Installing..."


### PR DESCRIPTION
closes #49

The primary symptom of the issue [seemed to be](https://github.com/bpkg/bpkg/issues/49#issuecomment-165513867) that in the case of running the script more than once, the already-existed directory is not deleted before the `git-clone`. Since the date of the issue, this has already been fixed. But, error handling can still be improved.