### PR TITLE
Gitlab support

### DIFF
--- a/.shellspec
+++ b/.shellspec
@@ -1,0 +1,12 @@
+--require spec_helper
+
+## Default kcov (coverage) options
+# --kcov-options "--include-path=. --path-strip-level=1"
+# --kcov-options "--include-pattern=.sh"
+# --kcov-options "--exclude-pattern=/.shellspec,/spec/,/coverage/,/report/"
+
+## Example: Include script "myprog" with no extension
+# --kcov-options "--include-pattern=.sh,myprog"
+
+## Example: Only specified files/directories
+# --kcov-options "--include-pattern=myprog,/lib/"

--- a/README.md
+++ b/README.md
@@ -187,6 +187,32 @@ BPKG_GIT_REMOTES+=("https://gitlab.com")
 BPKG_GIT_REMOTES+=("https://my-git.com")
 ```
 
+### Using other git repositories
+
+`bpkg` resolves Github and Gitlab URL to find the package to install but 
+when a different git hosting service is used a method to resolve the right
+URL must be provided. To do so define a function named `bpkg_resolve_uri_pathspec`
+in the `$HOME/.bpkgrc` configuration file and let it do your git service resolution
+
+```bash
+    bpkg_resolve_uri_pathspec() {
+      local git_remote=$1
+      local user=$2
+      local name=$3
+      local version=$4
+
+      if [[ "$git_remote" == https://my-hosted-git*  ]]; then
+        echo "$version/$user/-/my-branch/$name"
+        return 0
+      else
+
+      return 1
+    }
+```
+
+Returning 0 signals that the URl have been resolved, other value means no resolution
+and let's `bpkg` resolve it for you
+
 ## Package details
 
 Here we lay down some info on the structure of a package.

--- a/README.md
+++ b/README.md
@@ -173,6 +173,20 @@ bpkg package
 ["install"]     "make install"
 ```
 
+### Configuration
+
+Github and Gitlab bash repositories have builtin support but in case other git repository needs to be searched for add the next lines to `$HOME/.bpkgrc` configuration file using the BPKG_REMOTES for raw file access and BPKG_GIT_REMOTES for git access
+
+```
+BPKG_REMOTES=("https://raw.githubusercontent.com")
+BPKG_REMOTES+=("https://gitlab.com")
+BPKG_REMOTES+=("https://my-git-raw-access.com")
+
+BPKG_GIT_REMOTES=("https://github.com")
+BPKG_GIT_REMOTES+=("https://gitlab.com")
+BPKG_GIT_REMOTES+=("https://my-git.com")
+```
+
 ## Package details
 
 Here we lay down some info on the structure of a package.

--- a/bpkg-url
+++ b/bpkg-url
@@ -1,0 +1,1 @@
+lib/utils/url.sh

--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -16,6 +16,7 @@ bpkg_exec_or_exit bpkg-realpath &&
 bpkg_exec_or_exit bpkg-getdeps &&
   source "$(which bpkg-getdeps)"
 
+# shellcheck source=lib/utils/url.sh
 bpkg_exec_or_exit bpkg-url &&
   source "$(which bpkg-url)"
 
@@ -287,7 +288,7 @@ bpkg_install_from_remote () {
       git_remote=${git_remote/https:\/\//https:\/\/$token:x-oauth-basic@}
     fi
   else
-    uri=$(bpkg_solve_uri "$git_remote" "$user" "$name" "$version")
+    uri=$(bpkg_resolve_uri "$git_remote" "$user" "$name" "$version")
   fi
 
   ## clean up extra slashes in uri

--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -16,6 +16,9 @@ bpkg_exec_or_exit bpkg-realpath &&
 bpkg_exec_or_exit bpkg-getdeps &&
   source "$(which bpkg-getdeps)"
 
+bpkg_exec_or_exit bpkg-url &&
+  source "$(which bpkg-url)"
+
 bpkg_initrc
 
 let prevent_prune=0
@@ -191,19 +194,6 @@ bpkg_install () {
   fi
 
   return 0
-}
-
-bpkg_solve_uri() {
-  local git_remote=$1
-  local user=$2
-  local name=$3
-  local version=$4
-
-  if [[ "$git_remote" == https://gitlab*  ]]; then
-    echo "$user/$name/-/raw/$version"
-  else
-    echo "$user/$name/$version"
-  fi
 }
 
 ## try to install a package from a specific remote

--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -297,7 +297,7 @@ bpkg_install_from_remote () {
       git_remote=${git_remote/https:\/\//https:\/\/$token:x-oauth-basic@}
     fi
   else
-    uri=$(bpkg_solve_uri "$git_remote" $user $name $version)
+    uri=$(bpkg_solve_uri "$git_remote" "$user" "$name" "$version")
   fi
 
   ## clean up extra slashes in uri

--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -193,6 +193,19 @@ bpkg_install () {
   return 0
 }
 
+bpkg_solve_uri() {
+  local git_remote=$1
+  local user=$2
+  local name=$3
+  local version=$4
+
+  if [[ "$git_remote" == https://gitlab*  ]]; then
+    echo "$user/$name/-/raw/$version"
+  else
+    echo "$user/$name/$version"
+  fi
+}
+
 ## try to install a package from a specific remote
 ## returns values:
 ##   0: success
@@ -284,7 +297,7 @@ bpkg_install_from_remote () {
       git_remote=${git_remote/https:\/\//https:\/\/$token:x-oauth-basic@}
     fi
   else
-    uri="/$user/$name/$version"
+    uri=$(bpkg_solve_uri "$git_remote" $user $name $version)
   fi
 
   ## clean up extra slashes in uri
@@ -306,7 +319,7 @@ bpkg_install_from_remote () {
   url="$remote/$uri"
   local nonce="$(date +%s)"
 
-  if url_exists "$url/bpkg.json?$nonce" "$auth_param"; then
+    if url_exists "$url/bpkg.json?$nonce" "$auth_param"; then
     ## read 'bpkg.json'
     json=$(fetch "$url/bpkg.json?$nonce" "$auth_param")
     package_file='bpkg.json'

--- a/lib/install/install.sh
+++ b/lib/install/install.sh
@@ -310,7 +310,7 @@ bpkg_install_from_remote () {
   url="$remote/$uri"
   local nonce="$(date +%s)"
 
-    if url_exists "$url/bpkg.json?$nonce" "$auth_param"; then
+  if url_exists "$url/bpkg.json?$nonce" "$auth_param"; then
     ## read 'bpkg.json'
     json=$(fetch "$url/bpkg.json?$nonce" "$auth_param")
     package_file='bpkg.json'

--- a/lib/utils/url.sh
+++ b/lib/utils/url.sh
@@ -5,7 +5,7 @@ if [ -z "${BPKG_URL}" ]; then
 
   ## Collection of shared bpkg functions
 
-  bpkg_solve_uri() {
+  bpkg_resolve_uri_default() {
     local git_remote=$1
     local user=$2
     local name=$3
@@ -18,5 +18,14 @@ if [ -z "${BPKG_URL}" ]; then
     fi
   }
 
-  export -f bpkg_solve_uri
+  bpkg_resolve_uri() {
+    [[ $(type -t bpkg_resolve_uri_pathspec) == function ]] && \
+      bpkg_resolve_uri_pathspec "$@" 
+    # shellcheck disable=SC2181
+    [[ $? -eq 0 ]] && return 
+    bpkg_resolve_uri_default "$@"
+  }
+
+  export -f bpkg_resolve_uri
+  export -f bpkg_resolve_uri_default
 fi

--- a/lib/utils/url.sh
+++ b/lib/utils/url.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+if [ -z "${BPKG_URL}" ]; then
+  BPKG_URL=1
+
+  ## Collection of shared bpkg functions
+
+  bpkg_solve_uri() {
+    local git_remote=$1
+    local user=$2
+    local name=$3
+    local version=$4
+
+    if [[ "$git_remote" == https://gitlab*  ]]; then
+      echo "$user/$name/-/raw/$version"
+    else
+      echo "$user/$name/$version"
+    fi
+  }
+
+  export -f bpkg_solve_uri
+fi

--- a/lib/utils/url.sh
+++ b/lib/utils/url.sh
@@ -19,11 +19,11 @@ if [ -z "${BPKG_URL}" ]; then
   }
 
   bpkg_resolve_uri() {
-    [[ $(type -t bpkg_resolve_uri_pathspec) == function ]] && \
-      bpkg_resolve_uri_pathspec "$@" 
-    # shellcheck disable=SC2181
-    [[ $? -eq 0 ]] && return 
-    bpkg_resolve_uri_default "$@"
+    if [[ $(type -t bpkg_resolve_uri_pathspec) == function ]]; then
+      bpkg_resolve_uri_pathspec "$@" || bpkg_resolve_uri_default "$@"
+    else
+      bpkg_resolve_uri_default "$@"
+    fi
   }
 
   export -f bpkg_resolve_uri

--- a/lib/utils/utils.sh
+++ b/lib/utils/utils.sh
@@ -17,6 +17,8 @@ if [ -z "${BPKG_UTILS}" ]; then
     if [ ${#BPKG_REMOTES[@]} -eq 0 ]; then
       BPKG_REMOTES[0]=${BPKG_REMOTE-https://raw.githubusercontent.com}
       BPKG_GIT_REMOTES[0]=${BPKG_GIT_REMOTE-https://github.com}
+      BPKG_REMOTES[1]=${https://gitlab.com}
+      BPKG_GIT_REMOTES[1]=${https://gitlab.com}
 
       export BPKG_REMOTES
       export BPKG_GIT_REMOTE

--- a/lib/utils/utils.sh
+++ b/lib/utils/utils.sh
@@ -17,8 +17,8 @@ if [ -z "${BPKG_UTILS}" ]; then
     if [ ${#BPKG_REMOTES[@]} -eq 0 ]; then
       BPKG_REMOTES[0]=${BPKG_REMOTE-https://raw.githubusercontent.com}
       BPKG_GIT_REMOTES[0]=${BPKG_GIT_REMOTE-https://github.com}
-      BPKG_REMOTES[1]=${https://gitlab.com}
-      BPKG_GIT_REMOTES[1]=${https://gitlab.com}
+      BPKG_REMOTES[1]="https://gitlab.com"
+      BPKG_GIT_REMOTES[1]="https://gitlab.com"
 
       export BPKG_REMOTES
       export BPKG_GIT_REMOTE

--- a/setup.sh
+++ b/setup.sh
@@ -94,6 +94,7 @@ CMDS+=("suggest")
 CMDS+=("term")
 CMDS+=("update")
 CMDS+=("utils")
+CMDS+=("url")
 CMDS+=("realpath")
 
 make_install () {

--- a/spec/lib/util/url_spec.sh
+++ b/spec/lib/util/url_spec.sh
@@ -1,18 +1,43 @@
 Describe 'url.sh'
   Include lib/utils/url.sh
-  
-  It 'solves Gitlab'
-    When call bpkg_solve_uri 'https://gitlab.com' bb cc dd
-    The output should equal 'bb/cc/-/raw/dd'
-  End
-  
-  It 'solves Github'
-    When call bpkg_solve_uri 'https://github.com' bb cc dd
-    The output should equal 'bb/cc/dd'
+
+  Describe 'internal resolution'
+    It 'solves Gitlab'
+      When call bpkg_resolve_uri 'https://gitlab.com' bb cc dd
+      The output should equal 'bb/cc/-/raw/dd'
+    End
+    
+    It 'solves Github'
+      When call bpkg_resolve_uri 'https://github.com' bb cc dd
+      The output should equal 'bb/cc/dd'
+    End
+
+    It 'solves everything else'
+      When call bpkg_resolve_uri 'https://my-git-domain.pe' bb cc dd
+      The output should equal 'bb/cc/dd'
+    End 
   End
 
-  It 'solves everything else'
-    When call bpkg_solve_uri 'https://my-git-domain.pe' bb cc dd
-    The output should equal 'bb/cc/dd'
+  Describe 'user defined resolution'
+
+    bpkg_resolve_uri_pathspec() {
+      echo "$4/$3/my-branch/$2"
+      return 0
+    }
+
+    It 'solves other services'
+      When call bpkg_resolve_uri 'https://any-url' bb cc dd
+      The output should equal 'dd/cc/my-branch/bb'
+    End
+
+
+    bpkg_resolve_uri_pathspec() {
+      return 1
+    }
+
+    It 'other services does not resolve use default resolution'
+      When call bpkg_resolve_uri 'https://github.com' bb cc dd
+      The output should equal 'bb/cc/dd'
+    End 
   End
 End

--- a/spec/lib/util/url_spec.sh
+++ b/spec/lib/util/url_spec.sh
@@ -1,3 +1,5 @@
+# shellcheck disable=SC2317,SC2148
+
 Describe 'url.sh'
   Include lib/utils/url.sh
 

--- a/spec/lib/util/url_spec.sh
+++ b/spec/lib/util/url_spec.sh
@@ -1,0 +1,18 @@
+Describe 'url.sh'
+  Include lib/utils/url.sh
+  
+  It 'solves Gitlab'
+    When call bpkg_solve_uri 'https://gitlab.com' bb cc dd
+    The output should equal 'bb/cc/-/raw/dd'
+  End
+  
+  It 'solves Github'
+    When call bpkg_solve_uri 'https://github.com' bb cc dd
+    The output should equal 'bb/cc/dd'
+  End
+
+  It 'solves everything else'
+    When call bpkg_solve_uri 'https://my-git-domain.pe' bb cc dd
+    The output should equal 'bb/cc/dd'
+  End
+End

--- a/spec/spec_helper.sh
+++ b/spec/spec_helper.sh
@@ -1,0 +1,24 @@
+# shellcheck shell=sh
+
+# Defining variables and functions here will affect all specfiles.
+# Change shell options inside a function may cause different behavior,
+# so it is better to set them here.
+# set -eu
+
+# This callback function will be invoked only once before loading specfiles.
+spec_helper_precheck() {
+  # Available functions: info, warn, error, abort, setenv, unsetenv
+  # Available variables: VERSION, SHELL_TYPE, SHELL_VERSION
+  : minimum_version "0.28.1"
+}
+
+# This callback function will be invoked after a specfile has been loaded.
+spec_helper_loaded() {
+  :
+}
+
+# This callback function will be invoked after core modules has been loaded.
+spec_helper_configure() {
+  # Available functions: import, before_each, after_each, before_all, after_all
+  : import 'support/custom_matcher'
+}


### PR DESCRIPTION
Currently bpkg repositories can be stored using Github. This PR adds Gitlab support
Can be tested by running `bpkg install bit-man/forrest-tools` located at https://gitlab.com/bit-man/forrest-tools